### PR TITLE
feat: add LastPass sync and opt-in scheduler

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# commit-msg — every commit references an issue: (refs #N) or (closes #N).
+
+msg="$(cat "$1")"
+
+case "$msg" in
+  Merge*) exit 0 ;;
+esac
+
+if printf '%s' "$msg" | grep -qE '\((refs|closes) #[0-9]+\)'; then
+  exit 0
+fi
+
+echo "commit-msg: message must reference an issue: '(refs #N)' or '(closes #N)'." >&2
+echo "  file one first if none exists; the issue is the lab notebook." >&2
+exit 1

--- a/README.md
+++ b/README.md
@@ -108,30 +108,38 @@ The sync runs wherever both hush and the official `lpass` CLI run: macOS, Linux,
 official CLI does not currently provide a native PowerShell or Node entry point, so native Windows
 remains limited by that dependency rather than by the hush store backend.
 
-### schedule it while the LastPass CLI session is active (macOS)
+### schedule it with experimental auto-login (macOS)
 
 A cold npm install includes an optional Node-based launchd helper:
 
 ```sh
 npm install -g @royashbrook/hush
 brew install lastpass-cli
-LPASS_AGENT_TIMEOUT=0 lpass login --trust you@example.com
-hush-lastpass-schedule install --every 6h
+hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
 hush-lastpass-schedule status
 ```
 
-`LPASS_AGENT_TIMEOUT=0` keeps the official CLI's in-memory agent alive for the current login
-session. The scheduler never stores LastPass login material and never uses `lpass --plaintext-key`.
-After a reboot, logout, or expired session, jobs fail closed until the interactive login is repeated.
-Use `hush-lastpass-schedule remove` to unload the job; its non-secret config is retained.
+Auto-login is experimental. Its complete contract passes deterministic fake-CLI tests, but we could
+not complete a real trusted login because Homebrew `lastpass-cli` crashed in its MFA path before any
+vault access. This matches upstream [`lastpass-cli` issue
+#719](https://github.com/lastpass/lastpass-cli/issues/719). It may work with account/MFA combinations
+unaffected by that bug, but it is not live-tested.
+
+The design performs one interactive `lpass login --trust`, then asks once for the LastPass master
+password through hush's hidden prompt. Scheduled runs are intended to use that local Keychain value
+to restore the `lpass` session after reboot. This is explicit opt-in: no LastPass login material is
+stored unless `--auto-login` is present. The helper never uses `lpass --plaintext-key`, and its
+dedicated login secret is always excluded from vault sync. Failed setup installs nothing; revoked or
+expired trust makes later jobs fail closed.
+
+Use `hush-lastpass-schedule remove` to unload the job. It retains the non-secret config and the hush
+login secret so removal cannot silently destroy credentials. Delete that secret separately with
+`hush rm hush-lastpass-master-password` if you want to revoke the opt-in completely.
 
 An API key cannot replace this login: the published [LastPass Business
 API](https://developer.lastpass.com/business/docs/index.md) manages accounts, companies, and
-reports, but does not expose vault-item writes. LastPass Authenticator users may also hit the
-upstream [`lastpass-cli` MFA failure](https://github.com/lastpass/lastpass-cli/issues/719), which we
-reproduced as a macOS segmentation fault before any vault access. The scheduler is Node so other
-native schedulers can be added without changing the sync contract, but this release installs
-launchd on macOS only.
+reports, but does not expose vault-item writes. The scheduler is Node so other native schedulers can
+be added without changing the sync contract, but this release installs launchd on macOS only.
 
 ## not a vault
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ lpass login you@example.com
 hush sync lastpass --dry-run                  # names + destinations only, no values fetched
 hush sync lastpass                            # all names -> hush/<name>
 hush sync lastpass --group team/secrets api-key deploy-key
+hush sync lastpass --exclude local-only       # repeat to keep local-only names out of bulk sync
 ```
 
 This is an upsert into each LastPass entry's password field. A missing entry is created, a unique
@@ -106,6 +107,33 @@ edits accept one line and would otherwise truncate them.
 The sync runs wherever both hush and the official `lpass` CLI run: macOS, Linux, and Cygwin. The
 official CLI does not currently provide a native PowerShell or Node entry point, so native Windows
 remains limited by that dependency rather than by the hush store backend.
+
+### schedule it without logging in after every reboot (macOS)
+
+A cold npm install includes an optional Node-based launchd helper:
+
+```sh
+npm install -g @royashbrook/hush
+brew install lastpass-cli
+hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
+hush-lastpass-schedule status
+```
+
+Setup performs one interactive `lpass login --trust`, then asks once for the LastPass master
+password through hush's hidden prompt. Scheduled runs can use that local Keychain value to restore
+the `lpass` session after a reboot. This is explicit opt-in: no LastPass login material is stored
+unless `--auto-login` is present. The helper never uses `lpass --plaintext-key`, and its dedicated
+login secret is always excluded from vault sync. If LastPass revokes or expires the trusted-device
+grant, the job fails closed until setup is run interactively again.
+
+Use `hush-lastpass-schedule remove` to unload the job. It retains the non-secret config and the hush
+login secret so removal cannot silently destroy credentials. Delete that secret separately with
+`hush rm hush-lastpass-master-password` if you want to revoke the opt-in completely.
+
+An API key cannot replace this login: the published [LastPass Business
+API](https://developer.lastpass.com/business/docs/index.md) manages accounts, companies, and
+reports, but does not expose vault-item writes. The scheduler is Node so other native schedulers can
+be added without changing the sync contract, but this release installs launchd on macOS only.
 
 ## not a vault
 

--- a/README.md
+++ b/README.md
@@ -108,32 +108,30 @@ The sync runs wherever both hush and the official `lpass` CLI run: macOS, Linux,
 official CLI does not currently provide a native PowerShell or Node entry point, so native Windows
 remains limited by that dependency rather than by the hush store backend.
 
-### schedule it without logging in after every reboot (macOS)
+### schedule it while the LastPass CLI session is active (macOS)
 
 A cold npm install includes an optional Node-based launchd helper:
 
 ```sh
 npm install -g @royashbrook/hush
 brew install lastpass-cli
-hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
+LPASS_AGENT_TIMEOUT=0 lpass login --trust you@example.com
+hush-lastpass-schedule install --every 6h
 hush-lastpass-schedule status
 ```
 
-Setup performs one interactive `lpass login --trust`, then asks once for the LastPass master
-password through hush's hidden prompt. Scheduled runs can use that local Keychain value to restore
-the `lpass` session after a reboot. This is explicit opt-in: no LastPass login material is stored
-unless `--auto-login` is present. The helper never uses `lpass --plaintext-key`, and its dedicated
-login secret is always excluded from vault sync. If LastPass revokes or expires the trusted-device
-grant, the job fails closed until setup is run interactively again.
-
-Use `hush-lastpass-schedule remove` to unload the job. It retains the non-secret config and the hush
-login secret so removal cannot silently destroy credentials. Delete that secret separately with
-`hush rm hush-lastpass-master-password` if you want to revoke the opt-in completely.
+`LPASS_AGENT_TIMEOUT=0` keeps the official CLI's in-memory agent alive for the current login
+session. The scheduler never stores LastPass login material and never uses `lpass --plaintext-key`.
+After a reboot, logout, or expired session, jobs fail closed until the interactive login is repeated.
+Use `hush-lastpass-schedule remove` to unload the job; its non-secret config is retained.
 
 An API key cannot replace this login: the published [LastPass Business
 API](https://developer.lastpass.com/business/docs/index.md) manages accounts, companies, and
-reports, but does not expose vault-item writes. The scheduler is Node so other native schedulers can
-be added without changing the sync contract, but this release installs launchd on macOS only.
+reports, but does not expose vault-item writes. LastPass Authenticator users may also hit the
+upstream [`lastpass-cli` MFA failure](https://github.com/lastpass/lastpass-cli/issues/719), which we
+reproduced as a macOS segmentation fault before any vault access. The scheduler is Node so other
+native schedulers can be added without changing the sync contract, but this release installs
+launchd on macOS only.
 
 ## not a vault
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ printf '%s' "$TOK" | hush set my-vendor-token # ...or pipe it in (scripts/CI), s
 hush set my-vendor-token --gui                # force the dialog (or --tty / --pipe; HUSH_PROMPT= too)
 hush mint app-operator-key                    # generate + store a random one
 hush run TOKEN=my-vendor-token -- some-cmd    # inject into a command, never printed
+hush sync lastpass --dry-run                  # preview a one-way LastPass sync
+hush sync lastpass                            # upsert every name under LastPass group "hush"
 hush list                                     # names only, never values
 ```
 
@@ -82,6 +84,28 @@ Naming: keep the default `hush` namespace and **prefix names by project** (`blam
 genuinely separate store, not per-project. Need to fix an existing name? `hush rename <old> <new>`
 moves the value internally (never re-asked, never printed). Full docs + the portable contract:
 [SKILL.md](SKILL.md).
+
+## sync to LastPass
+
+Install and log into the official LastPass CLI once, then preview and run the sync:
+
+```sh
+brew install lastpass-cli                     # macOS
+lpass login you@example.com
+hush sync lastpass --dry-run                  # names + destinations only, no values fetched
+hush sync lastpass                            # all names -> hush/<name>
+hush sync lastpass --group team/secrets api-key deploy-key
+```
+
+This is an upsert into each LastPass entry's password field. A missing entry is created, a unique
+entry is updated, and duplicate LastPass names fail closed. Values move over stdin, never argv,
+stdout, or a temp file. Each write uses `--sync=now`, so hush reports success only after LastPass has
+synchronized it to the server. Multiline hush values are refused because `lpass` password-field
+edits accept one line and would otherwise truncate them.
+
+The sync runs wherever both hush and the official `lpass` CLI run: macOS, Linux, and Cygwin. The
+official CLI does not currently provide a native PowerShell or Node entry point, so native Windows
+remains limited by that dependency rather than by the hush store backend.
 
 ## not a vault
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hush
 description: Use whenever an agent needs to STORE, GENERATE, or USE a secret (API token, key, signing value, password) without ever exposing the plaintext. Replaces the "go set this env var / paste this token into that system" dance with one structured, OS-keychain-backed flow where the value goes straight from source into the consumer and never passes through the agent (no transcript, no logs, no cloud). Two add-paths: a value you GENERATED elsewhere (a vendor token, a PAT) gets pasted in once via a hidden prompt the agent can't see; a value that just needs to be STRONG+RANDOM (an operator key, a webhook signing secret) the agent generates and stores itself. Then it injects straight into the consumer (an env var, or a command's stdin), never printed, so an agent running as the user, with their CLIs already authed, can set server-side secrets and call services without the value ever touching the chat or disk. Triggers: "store this token", "save this key", "add it to the keychain", "generate an operator/signing key", "use the X secret to call Y", or any moment an agent needs a credential to reach a service. macOS, Linux, and Windows backends built in; the never-print contract is portable beyond them.
-version: 1.3.1
+version: 1.4.0
 ---
 
 # hush
@@ -112,6 +112,7 @@ So a secret that doesn't need the human never blocks on the human.
 ```
 hush run NAME=VAR [N2=V2 ...] -- <cmd>   # fetch into env vars, exec <cmd> (value only in the child)
 hush pipe <name> -- <cmd>                # stream the value to <cmd>'s stdin
+hush sync lastpass [name ...]            # upsert selected names, or all names when omitted
 hush list                                # NAMES only, never values
 hush rename <old> <new>                  # move to a new name (value moved INTERNALLY, never re-asked)
 hush rm   <name>                         # delete
@@ -121,6 +122,20 @@ hush rm   <name>                         # delete
 server-side secret (`hush pipe gh-pat -- gh secret set X`, `hush pipe key -- npx wrangler secret put
 X`); **run** a command with the value in its environment to call a service (`hush run TOKEN=t --
 curl ...`). The value lives only in that child process , never on disk, never printed.
+
+For a durable LastPass copy, use the built-in one-way sync after the official `lpass` CLI is logged
+in:
+
+```
+hush sync lastpass --dry-run                  # validate login, list destinations, read no values
+hush sync lastpass                            # all names -> LastPass hush/<name>
+hush sync lastpass --group team/secrets foo   # selected name -> team/secrets/foo
+```
+
+The command edits only the LastPass password field. It creates missing entries, updates unique
+entries, fails on duplicate names, and uses a blocking server sync before reporting success. Values
+travel on stdin and `lpass` output is suppressed. Multiline values are refused rather than silently
+truncated. The official LastPass CLI supports macOS, Linux, and Cygwin, not native PowerShell/Node.
 
 > **Escape hatch, `hush file <name> <path>`.** A few tools can *only* read a credential from a file
 > path (a service-account JSON, a cert, a kubeconfig). For those, and only those, `hush file` writes a
@@ -224,9 +239,9 @@ a sticky note.
 Treat it as an **on-ramp.** Two wins land immediately, even with no `hush exec` in sight: you can
 generate secrets securely from day one, and on an old project with values scattered across `.env`s,
 dashboards, and your head, a few pastes get them (a) centralized and (b) agent-usable from then on.
-For a durable, shareable home, **sync them onward** into a real secret manager, see *extending
-hush* for wiring a 1Password / vault / pass backend. hush gets you consistent; the sync makes it
-permanent.
+For a durable, shareable home, **sync them onward** into a real secret manager. LastPass has a
+built-in one-way sync, and *extending hush* covers other CLIs and store backends. hush gets you
+consistent; the sync makes it permanent.
 
 ## extending hush to the tools you already use
 
@@ -234,8 +249,8 @@ The friction this kills: *"go create this key, then paste it into GitHub / Wrang
 tell me when it's there."* If the agent already has the CLI for that tool, it shouldn't hand that
 back, it should just do it. Two directions:
 
-1. **Push a hush-held secret INTO another tool** (it's already built, via `pipe`). Anything with a
-   CLI that takes the value on stdin is a consumer:
+1. **Push a hush-held secret INTO another tool.** LastPass is built in as `hush sync lastpass`.
+   Anything else with a CLI that takes the value on stdin is already a consumer via `pipe`:
    ```
    hush pipe deploy-token -- gh secret set DEPLOY_TOKEN          # into GitHub Actions
    hush pipe api-key      -- npx wrangler secret put API_KEY     # into a Worker

--- a/SKILL.md
+++ b/SKILL.md
@@ -139,20 +139,23 @@ entries, fails on duplicate names, and uses a blocking server sync before report
 travel on stdin and `lpass` output is suppressed. Multiline values are refused rather than silently
 truncated. The official LastPass CLI supports macOS, Linux, and Cygwin, not native PowerShell/Node.
 
-For scheduled macOS sync while the LastPass CLI session is active, the npm package also installs a
-Node helper:
+For experimental opt-in macOS sync after reboot, the npm package also installs the Node helper:
 
 ```
-LPASS_AGENT_TIMEOUT=0 lpass login --trust you@example.com
-hush-lastpass-schedule install --every 6h
+hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
 hush-lastpass-schedule status
 hush-lastpass-schedule remove
 ```
 
-The helper stores no LastPass login material and never uses `lpass --plaintext-key`. A reboot,
-logout, or expired session makes scheduled runs fail closed until interactive login is repeated.
-LastPass Authenticator users may hit the upstream `lastpass-cli` out-of-band MFA failure documented
-in issue #719. The helper currently installs a macOS LaunchAgent only.
+The auto-login contract passes deterministic fake-CLI tests but is not live-tested: Homebrew
+`lastpass-cli` crashed during out-of-band MFA before vault access, matching upstream issue #719.
+Accounts unaffected by that bug may work. Setup performs one interactive trusted-device login and
+stores the master password under
+`hush-lastpass-master-password` through hush's hidden prompt. The runner reauthenticates through
+`hush pipe`, never uses `lpass --plaintext-key`, and always excludes that auth secret from sync. A
+failed setup installs nothing. A revoked or expired LastPass trust grant fails closed and requires
+interactive setup again. Without `--auto-login`, the helper schedules sync but requires an
+already-live `lpass` session. The helper currently installs a macOS LaunchAgent only.
 
 > **Escape hatch, `hush file <name> <path>`.** A few tools can *only* read a credential from a file
 > path (a service-account JSON, a cert, a kubeconfig). For those, and only those, `hush file` writes a

--- a/SKILL.md
+++ b/SKILL.md
@@ -113,6 +113,7 @@ So a secret that doesn't need the human never blocks on the human.
 hush run NAME=VAR [N2=V2 ...] -- <cmd>   # fetch into env vars, exec <cmd> (value only in the child)
 hush pipe <name> -- <cmd>                # stream the value to <cmd>'s stdin
 hush sync lastpass [name ...]            # upsert selected names, or all names when omitted
+hush sync lastpass --exclude <name>       # keep a local-only name out of bulk sync; repeatable
 hush list                                # NAMES only, never values
 hush rename <old> <new>                  # move to a new name (value moved INTERNALLY, never re-asked)
 hush rm   <name>                         # delete
@@ -130,12 +131,28 @@ in:
 hush sync lastpass --dry-run                  # validate login, list destinations, read no values
 hush sync lastpass                            # all names -> LastPass hush/<name>
 hush sync lastpass --group team/secrets foo   # selected name -> team/secrets/foo
+hush sync lastpass --exclude local-only       # bulk sync except explicitly local names
 ```
 
 The command edits only the LastPass password field. It creates missing entries, updates unique
 entries, fails on duplicate names, and uses a blocking server sync before reporting success. Values
 travel on stdin and `lpass` output is suppressed. Multiline values are refused rather than silently
 truncated. The official LastPass CLI supports macOS, Linux, and Cygwin, not native PowerShell/Node.
+
+For opt-in unattended macOS sync after reboot, the npm package also installs the Node helper:
+
+```
+hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
+hush-lastpass-schedule status
+hush-lastpass-schedule remove
+```
+
+Setup performs one interactive trusted-device login and stores the master password under
+`hush-lastpass-master-password` through hush's hidden prompt. The runner reauthenticates through
+`hush pipe`, never uses `lpass --plaintext-key`, and always excludes that auth secret from sync. A
+revoked or expired LastPass trust grant fails closed and requires interactive setup again. Without
+`--auto-login`, the helper schedules sync but requires an already-live `lpass` session. The helper
+currently installs a macOS LaunchAgent only.
 
 > **Escape hatch, `hush file <name> <path>`.** A few tools can *only* read a credential from a file
 > path (a service-account JSON, a cert, a kubeconfig). For those, and only those, `hush file` writes a

--- a/SKILL.md
+++ b/SKILL.md
@@ -139,20 +139,20 @@ entries, fails on duplicate names, and uses a blocking server sync before report
 travel on stdin and `lpass` output is suppressed. Multiline values are refused rather than silently
 truncated. The official LastPass CLI supports macOS, Linux, and Cygwin, not native PowerShell/Node.
 
-For opt-in unattended macOS sync after reboot, the npm package also installs the Node helper:
+For scheduled macOS sync while the LastPass CLI session is active, the npm package also installs a
+Node helper:
 
 ```
-hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
+LPASS_AGENT_TIMEOUT=0 lpass login --trust you@example.com
+hush-lastpass-schedule install --every 6h
 hush-lastpass-schedule status
 hush-lastpass-schedule remove
 ```
 
-Setup performs one interactive trusted-device login and stores the master password under
-`hush-lastpass-master-password` through hush's hidden prompt. The runner reauthenticates through
-`hush pipe`, never uses `lpass --plaintext-key`, and always excludes that auth secret from sync. A
-revoked or expired LastPass trust grant fails closed and requires interactive setup again. Without
-`--auto-login`, the helper schedules sync but requires an already-live `lpass` session. The helper
-currently installs a macOS LaunchAgent only.
+The helper stores no LastPass login material and never uses `lpass --plaintext-key`. A reboot,
+logout, or expired session makes scheduled runs fail closed until interactive login is repeated.
+LastPass Authenticator users may hit the upstream `lastpass-cli` out-of-band MFA failure documented
+in issue #719. The helper currently installs a macOS LaunchAgent only.
 
 > **Escape hatch, `hush file <name> <path>`.** A few tools can *only* read a credential from a file
 > path (a service-account JSON, a cert, a kubeconfig). For those, and only those, `hush file` writes a

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -3,22 +3,22 @@
 Optional extras built ON TOP of the `hush` CLI. Some ship in the npm package and some remain
 repo-only. They may be platform-specific. Use or ignore freely.
 
-## hush-lastpass-schedule, unattended LastPass sync (macOS)
+## hush-lastpass-schedule, recurring LastPass sync (macOS)
 
-The npm package installs this Node helper beside `hush`. It creates a per-user launchd job and can
-optionally restore the LastPass CLI login after reboot from a master password held in hush:
+The npm package installs this Node helper beside `hush`. It creates a per-user launchd job:
 
 ```sh
-hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
+LPASS_AGENT_TIMEOUT=0 lpass login --trust you@example.com
+hush-lastpass-schedule install --every 6h
 hush-lastpass-schedule status
 hush-lastpass-schedule remove
 ```
 
-Auto-login is explicit opt-in. Setup performs one interactive trusted-device login, then stores the
-master password through hush's hidden prompt. The auth secret is forcibly excluded from every sync,
-`lpass --plaintext-key` is never used, and expired device trust fails closed. `remove` unloads the
-job but retains both config and the hush secret. The implementation is Node and stdlib-only; job
-installation currently targets macOS launchd.
+The helper stores no LastPass login material and never uses `lpass --plaintext-key`. The in-memory
+agent survives for the current login session; after reboot, logout, or expiry, jobs fail closed
+until interactive login is repeated. LastPass Authenticator may hit upstream `lastpass-cli` issue
+#719 during login. `remove` unloads the job but retains its non-secret config. The implementation is
+Node and stdlib-only; job installation currently targets macOS launchd.
 
 ## hush-backup, encrypted off-machine backup of the store (macOS + iCloud)
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,7 +1,24 @@
 # helpers/
 
-Optional extras built ON TOP of the `hush` CLI. They are not part of core hush, not covered by its
-tests, and may be platform-specific. Use or ignore freely.
+Optional extras built ON TOP of the `hush` CLI. Some ship in the npm package and some remain
+repo-only. They may be platform-specific. Use or ignore freely.
+
+## hush-lastpass-schedule, unattended LastPass sync (macOS)
+
+The npm package installs this Node helper beside `hush`. It creates a per-user launchd job and can
+optionally restore the LastPass CLI login after reboot from a master password held in hush:
+
+```sh
+hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
+hush-lastpass-schedule status
+hush-lastpass-schedule remove
+```
+
+Auto-login is explicit opt-in. Setup performs one interactive trusted-device login, then stores the
+master password through hush's hidden prompt. The auth secret is forcibly excluded from every sync,
+`lpass --plaintext-key` is never used, and expired device trust fails closed. `remove` unloads the
+job but retains both config and the hush secret. The implementation is Node and stdlib-only; job
+installation currently targets macOS launchd.
 
 ## hush-backup, encrypted off-machine backup of the store (macOS + iCloud)
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -3,22 +3,24 @@
 Optional extras built ON TOP of the `hush` CLI. Some ship in the npm package and some remain
 repo-only. They may be platform-specific. Use or ignore freely.
 
-## hush-lastpass-schedule, recurring LastPass sync (macOS)
+## hush-lastpass-schedule, experimental unattended LastPass sync (macOS)
 
-The npm package installs this Node helper beside `hush`. It creates a per-user launchd job:
+The npm package installs this Node helper beside `hush`. It creates a per-user launchd job and can
+optionally restore the LastPass CLI login after reboot from a master password held in hush:
 
 ```sh
-LPASS_AGENT_TIMEOUT=0 lpass login --trust you@example.com
-hush-lastpass-schedule install --every 6h
+hush-lastpass-schedule install --auto-login --email you@example.com --every 6h
 hush-lastpass-schedule status
 hush-lastpass-schedule remove
 ```
 
-The helper stores no LastPass login material and never uses `lpass --plaintext-key`. The in-memory
-agent survives for the current login session; after reboot, logout, or expiry, jobs fail closed
-until interactive login is repeated. LastPass Authenticator may hit upstream `lastpass-cli` issue
-#719 during login. `remove` unloads the job but retains its non-secret config. The implementation is
-Node and stdlib-only; job installation currently targets macOS launchd.
+Auto-login is explicit opt-in and not live-tested. Its deterministic fake-CLI contract passes, but
+Homebrew `lastpass-cli` crashed during real MFA before vault access, matching upstream issue #719.
+Setup performs one interactive trusted-device login, then stores the master password through hush's
+hidden prompt. The auth secret is forcibly excluded from every sync, `lpass --plaintext-key` is
+never used, failed setup installs nothing, and expired device trust fails closed. `remove` unloads
+the job but retains both config and the hush secret. The implementation is Node and stdlib-only; job
+installation currently targets macOS launchd.
 
 ## hush-backup, encrypted off-machine backup of the store (macOS + iCloud)
 

--- a/helpers/hush-lastpass-schedule.mjs
+++ b/helpers/hush-lastpass-schedule.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, delimiter, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const LABEL = 'com.royashbrook.hush.lastpass-sync';
+const SCRIPT = fileURLToPath(import.meta.url);
+
+function die(message) {
+  process.stderr.write(`hush-lastpass-schedule: ${message}\n`);
+  process.exit(1);
+}
+
+function usage(code = 0) {
+  const out = code ? process.stderr : process.stdout;
+  out.write(`hush-lastpass-schedule, recurring hush -> LastPass sync
+
+  hush-lastpass-schedule install --every 6h [--group path] [name ...]
+  hush-lastpass-schedule install --auto-login --email you@example.com [options]
+  hush-lastpass-schedule run
+  hush-lastpass-schedule status
+  hush-lastpass-schedule remove
+
+options:
+  --auto-login             opt in to storing the LastPass master password in hush
+  --email <address>        LastPass login email, required with --auto-login
+  --auth-secret <name>     hush name for the login secret (default: hush-lastpass-master-password)
+  --refresh-login-secret   replace an existing stored login secret during install
+  --every <Nm|Nh|Nd>       interval, minimum 5m (default: 6h)
+  --group <path>           LastPass group (default: hush)
+
+auto-login never uses lpass --plaintext-key. setup performs one interactive trusted-device login.
+if that trust is revoked or expires, scheduled runs fail closed until install/login is run again.
+`);
+  process.exit(code);
+}
+
+function roots() {
+  const home = process.env.HUSH_LASTPASS_SCHEDULE_HOME || homedir();
+  return {
+    home,
+    config: join(home, 'Library', 'Application Support', 'hush', 'lastpass-schedule.json'),
+    plist: join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`),
+    log: join(home, 'Library', 'Logs', 'hush-lastpass-sync.log'),
+  };
+}
+
+function findExecutable(name, override) {
+  if (override) {
+    if (existsSync(override)) return override;
+    die(`configured ${name} executable does not exist: ${override}`);
+  }
+  for (const dir of (process.env.PATH || '').split(delimiter)) {
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  die(`${name} is not on PATH`);
+}
+
+function run(program, args, options = {}) {
+  return spawnSync(program, args, {
+    encoding: 'utf8',
+    env: options.env || process.env,
+    stdio: options.stdio || 'pipe',
+  });
+}
+
+function seconds(value) {
+  const match = /^(\d+)(m|h|d)$/.exec(value);
+  if (!match) die(`bad interval '${value}' (use Nm, Nh, or Nd)`);
+  const unit = { m: 60, h: 3600, d: 86400 }[match[2]];
+  const result = Number(match[1]) * unit;
+  if (result < 300) die('interval must be at least 5m');
+  return result;
+}
+
+function xml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function writeAtomic(path, value, mode = 0o600) {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temp = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`);
+  writeFileSync(temp, value, { mode });
+  renameSync(temp, path);
+}
+
+function parseInstall(args) {
+  const result = {
+    every: '6h', group: 'hush', autoLogin: false, email: '',
+    authSecret: 'hush-lastpass-master-password', refresh: false, names: [],
+  };
+  while (args.length) {
+    const arg = args.shift();
+    if (arg === '--every') result.every = args.shift() || die('--every needs an interval');
+    else if (arg === '--group') result.group = args.shift() || die('--group needs a path');
+    else if (arg === '--email') result.email = args.shift() || die('--email needs an address');
+    else if (arg === '--auth-secret') result.authSecret = args.shift() || die('--auth-secret needs a name');
+    else if (arg === '--auto-login') result.autoLogin = true;
+    else if (arg === '--refresh-login-secret') result.refresh = true;
+    else if (arg === '--') { result.names.push(...args); break; }
+    else if (arg.startsWith('-')) die(`unknown option '${arg}'`);
+    else result.names.push(arg);
+  }
+  if (!result.group || result.group.endsWith('/')) die('--group must be non-empty and cannot end with /');
+  if (result.autoLogin && !result.email) die('--email is required with --auto-login');
+  if (result.refresh && !result.autoLogin) die('--refresh-login-secret requires --auto-login');
+  result.seconds = seconds(result.every);
+  return result;
+}
+
+function syncArgs(config, dryRun = false) {
+  const args = ['sync', 'lastpass', '--group', config.group];
+  if (config.autoLogin) args.push('--exclude', config.authSecret);
+  if (dryRun) args.push('--dry-run');
+  args.push(...config.names);
+  return args;
+}
+
+function readConfig(path) {
+  if (!existsSync(path)) die(`no schedule config at ${path} (run install)`);
+  try { return JSON.parse(readFileSync(path, 'utf8')); }
+  catch { die(`could not read schedule config at ${path}`); }
+}
+
+function install(args) {
+  const platform = process.env.HUSH_LASTPASS_SCHEDULE_PLATFORM || process.platform;
+  if (platform !== 'darwin') die('schedule install currently supports macOS launchd only');
+  const options = parseInstall(args);
+  const paths = roots();
+  const hush = findExecutable('hush', process.env.HUSH_LASTPASS_SCHEDULE_HUSH);
+  const lpass = findExecutable('lpass', process.env.HUSH_LASTPASS_SCHEDULE_LPASS);
+  const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
+
+  if (options.autoLogin) {
+    process.stdout.write('hush-lastpass-schedule: auto-login opt-in stores your LastPass master password in the local hush store.\n');
+    const login = run(lpass, ['login', '--trust', options.email], {
+      stdio: 'inherit',
+      env: { ...process.env, LPASS_AGENT_TIMEOUT: '0' },
+    });
+    if (login.status !== 0) die('interactive trusted-device login failed; nothing installed');
+
+    const listed = run(hush, ['list']);
+    const hasSecret = listed.status === 0 && listed.stdout.split(/\r?\n/).includes(options.authSecret);
+    if (!hasSecret || options.refresh) {
+      process.stdout.write(`hush-lastpass-schedule: storing login material as hush secret '${options.authSecret}'.\n`);
+      const stored = run(hush, ['set', options.authSecret], { stdio: 'inherit' });
+      if (stored.status !== 0) die('login secret was not stored; nothing installed');
+    }
+  } else {
+    const status = run(lpass, ['status', '--quiet', '--color=never']);
+    if (status.status !== 0) die('LastPass is not logged in; run lpass login first or use --auto-login');
+  }
+
+  const config = {
+    version: 1,
+    hush, lpass,
+    group: options.group,
+    names: options.names,
+    every: options.every,
+    seconds: options.seconds,
+    autoLogin: options.autoLogin,
+    email: options.email,
+    authSecret: options.authSecret,
+  };
+
+  const preview = run(hush, syncArgs(config, true), { stdio: 'inherit' });
+  if (preview.status !== 0) die('sync dry-run failed; nothing installed');
+  writeAtomic(paths.config, `${JSON.stringify(config, null, 2)}\n`);
+  mkdirSync(dirname(paths.log), { recursive: true });
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xml(process.execPath)}</string>
+    <string>${xml(SCRIPT)}</string>
+    <string>run</string>
+    <string>--config</string>
+    <string>${xml(paths.config)}</string>
+  </array>
+  <key>StartInterval</key><integer>${config.seconds}</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>${xml(paths.log)}</string>
+  <key>StandardErrorPath</key><string>${xml(paths.log)}</string>
+</dict>
+</plist>
+`;
+  writeAtomic(paths.plist, plist);
+
+  const domain = `gui/${process.getuid()}`;
+  run(launchctl, ['bootout', domain, paths.plist]);
+  const loaded = run(launchctl, ['bootstrap', domain, paths.plist]);
+  if (loaded.status !== 0) die(`launchctl bootstrap failed; config and plist remain at ${paths.plist}`);
+  process.stdout.write(`hush-lastpass-schedule: installed every ${config.every}. log: ${paths.log}\n`);
+}
+
+function scheduledRun(configPath) {
+  const config = readConfig(configPath);
+  if (run(config.lpass, ['status', '--quiet', '--color=never']).status !== 0) {
+    if (!config.autoLogin) die('LastPass is logged out and auto-login is disabled');
+    const env = {
+      ...process.env,
+      LPASS_AGENT_TIMEOUT: '0',
+      LPASS_DISABLE_PINENTRY: '1',
+    };
+    const login = run(config.hush, [
+      'pipe', config.authSecret, '--', config.lpass, 'login', '--trust', config.email,
+    ], { env });
+    if (login.status !== 0) die('automatic LastPass login failed; refresh trusted login interactively');
+  }
+
+  const synced = run(config.hush, syncArgs(config));
+  if (synced.status !== 0) die(`sync failed with exit ${synced.status}`);
+  process.stdout.write(`hush-lastpass-schedule: ${new Date().toISOString()} sync ok\n`);
+}
+
+function status() {
+  const paths = roots();
+  const config = readConfig(paths.config);
+  const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
+  const result = run(launchctl, ['print', `gui/${process.getuid()}/${LABEL}`]);
+  process.stdout.write(`hush-lastpass-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}, auto-login ${config.autoLogin ? 'enabled' : 'disabled'}\n`);
+  process.exit(result.status === 0 ? 0 : 1);
+}
+
+function remove() {
+  const paths = roots();
+  const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
+  run(launchctl, ['bootout', `gui/${process.getuid()}`, paths.plist]);
+  rmSync(paths.plist, { force: true });
+  process.stdout.write(`hush-lastpass-schedule: removed LaunchAgent. config retained at ${paths.config}.\n`);
+}
+
+const [command = 'help', ...args] = process.argv.slice(2);
+if (command === 'install') install(args);
+else if (command === 'run') {
+  let config = roots().config;
+  if (args[0] === '--config' && args[1]) config = args[1];
+  scheduledRun(config);
+} else if (command === 'status') status();
+else if (command === 'remove') remove();
+else if (command === 'help' || command === '--help' || command === '-h') usage(0);
+else usage(2);

--- a/helpers/hush-lastpass-schedule.mjs
+++ b/helpers/hush-lastpass-schedule.mjs
@@ -19,16 +19,22 @@ function usage(code = 0) {
   out.write(`hush-lastpass-schedule, recurring hush -> LastPass sync
 
   hush-lastpass-schedule install --every 6h [--group path] [name ...]
+  hush-lastpass-schedule install --auto-login --email you@example.com [options]
   hush-lastpass-schedule run
   hush-lastpass-schedule status
   hush-lastpass-schedule remove
 
 options:
+  --auto-login             experimental: opt in to storing the LastPass master password in hush
+  --email <address>        LastPass login email, required with --auto-login
+  --auth-secret <name>     hush name for the login secret (default: hush-lastpass-master-password)
+  --refresh-login-secret   replace an existing stored login secret during install
   --every <Nm|Nh|Nd>       interval, minimum 5m (default: 6h)
   --group <path>           LastPass group (default: hush)
 
-log in first with LPASS_AGENT_TIMEOUT=0 lpass login --trust <email>. after a reboot or logout,
-scheduled runs fail closed until that interactive login is repeated.
+auto-login never uses lpass --plaintext-key. its contract is covered by deterministic tests, but a
+real login could not be completed because lastpass-cli issue #719 crashes during some MFA flows.
+if trusted login fails, nothing is installed. if trust later expires, scheduled runs fail closed.
 `);
   process.exit(code);
 }
@@ -89,22 +95,32 @@ function writeAtomic(path, value, mode = 0o600) {
 }
 
 function parseInstall(args) {
-  const result = { every: '6h', group: 'hush', names: [] };
+  const result = {
+    every: '6h', group: 'hush', autoLogin: false, email: '',
+    authSecret: 'hush-lastpass-master-password', refresh: false, names: [],
+  };
   while (args.length) {
     const arg = args.shift();
     if (arg === '--every') result.every = args.shift() || die('--every needs an interval');
     else if (arg === '--group') result.group = args.shift() || die('--group needs a path');
+    else if (arg === '--email') result.email = args.shift() || die('--email needs an address');
+    else if (arg === '--auth-secret') result.authSecret = args.shift() || die('--auth-secret needs a name');
+    else if (arg === '--auto-login') result.autoLogin = true;
+    else if (arg === '--refresh-login-secret') result.refresh = true;
     else if (arg === '--') { result.names.push(...args); break; }
     else if (arg.startsWith('-')) die(`unknown option '${arg}'`);
     else result.names.push(arg);
   }
   if (!result.group || result.group.endsWith('/')) die('--group must be non-empty and cannot end with /');
+  if (result.autoLogin && !result.email) die('--email is required with --auto-login');
+  if (result.refresh && !result.autoLogin) die('--refresh-login-secret requires --auto-login');
   result.seconds = seconds(result.every);
   return result;
 }
 
 function syncArgs(config, dryRun = false) {
   const args = ['sync', 'lastpass', '--group', config.group];
+  if (config.autoLogin) args.push('--exclude', config.authSecret);
   if (dryRun) args.push('--dry-run');
   args.push(...config.names);
   return args;
@@ -125,8 +141,25 @@ function install(args) {
   const lpass = findExecutable('lpass', process.env.HUSH_LASTPASS_SCHEDULE_LPASS);
   const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
 
-  const status = run(lpass, ['status', '--quiet', '--color=never']);
-  if (status.status !== 0) die('LastPass is not logged in; run LPASS_AGENT_TIMEOUT=0 lpass login --trust <email> first');
+  if (options.autoLogin) {
+    process.stdout.write('hush-lastpass-schedule: auto-login opt-in stores your LastPass master password in the local hush store.\n');
+    const login = run(lpass, ['login', '--trust', options.email], {
+      stdio: 'inherit',
+      env: { ...process.env, LPASS_AGENT_TIMEOUT: '0' },
+    });
+    if (login.status !== 0) die('interactive trusted-device login failed; nothing installed');
+
+    const listed = run(hush, ['list']);
+    const hasSecret = listed.status === 0 && listed.stdout.split(/\r?\n/).includes(options.authSecret);
+    if (!hasSecret || options.refresh) {
+      process.stdout.write(`hush-lastpass-schedule: storing login material as hush secret '${options.authSecret}'.\n`);
+      const stored = run(hush, ['set', options.authSecret], { stdio: 'inherit' });
+      if (stored.status !== 0) die('login secret was not stored; nothing installed');
+    }
+  } else {
+    const status = run(lpass, ['status', '--quiet', '--color=never']);
+    if (status.status !== 0) die('LastPass is not logged in; run lpass login first or use --auto-login');
+  }
 
   const config = {
     version: 1,
@@ -135,6 +168,9 @@ function install(args) {
     names: options.names,
     every: options.every,
     seconds: options.seconds,
+    autoLogin: options.autoLogin,
+    email: options.email,
+    authSecret: options.authSecret,
   };
 
   const preview = run(hush, syncArgs(config, true), { stdio: 'inherit' });
@@ -174,7 +210,16 @@ function install(args) {
 function scheduledRun(configPath) {
   const config = readConfig(configPath);
   if (run(config.lpass, ['status', '--quiet', '--color=never']).status !== 0) {
-    die('LastPass is logged out; run LPASS_AGENT_TIMEOUT=0 lpass login --trust <email> interactively');
+    if (!config.autoLogin) die('LastPass is logged out and auto-login is disabled');
+    const env = {
+      ...process.env,
+      LPASS_AGENT_TIMEOUT: '0',
+      LPASS_DISABLE_PINENTRY: '1',
+    };
+    const login = run(config.hush, [
+      'pipe', config.authSecret, '--', config.lpass, 'login', '--trust', config.email,
+    ], { env });
+    if (login.status !== 0) die('automatic LastPass login failed; refresh trusted login interactively');
   }
 
   const synced = run(config.hush, syncArgs(config));
@@ -187,7 +232,7 @@ function status() {
   const config = readConfig(paths.config);
   const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
   const result = run(launchctl, ['print', `gui/${process.getuid()}/${LABEL}`]);
-  process.stdout.write(`hush-lastpass-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}\n`);
+  process.stdout.write(`hush-lastpass-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}, auto-login ${config.autoLogin ? 'enabled' : 'disabled'}\n`);
   process.exit(result.status === 0 ? 0 : 1);
 }
 

--- a/helpers/hush-lastpass-schedule.mjs
+++ b/helpers/hush-lastpass-schedule.mjs
@@ -19,21 +19,16 @@ function usage(code = 0) {
   out.write(`hush-lastpass-schedule, recurring hush -> LastPass sync
 
   hush-lastpass-schedule install --every 6h [--group path] [name ...]
-  hush-lastpass-schedule install --auto-login --email you@example.com [options]
   hush-lastpass-schedule run
   hush-lastpass-schedule status
   hush-lastpass-schedule remove
 
 options:
-  --auto-login             opt in to storing the LastPass master password in hush
-  --email <address>        LastPass login email, required with --auto-login
-  --auth-secret <name>     hush name for the login secret (default: hush-lastpass-master-password)
-  --refresh-login-secret   replace an existing stored login secret during install
   --every <Nm|Nh|Nd>       interval, minimum 5m (default: 6h)
   --group <path>           LastPass group (default: hush)
 
-auto-login never uses lpass --plaintext-key. setup performs one interactive trusted-device login.
-if that trust is revoked or expires, scheduled runs fail closed until install/login is run again.
+log in first with LPASS_AGENT_TIMEOUT=0 lpass login --trust <email>. after a reboot or logout,
+scheduled runs fail closed until that interactive login is repeated.
 `);
   process.exit(code);
 }
@@ -94,32 +89,22 @@ function writeAtomic(path, value, mode = 0o600) {
 }
 
 function parseInstall(args) {
-  const result = {
-    every: '6h', group: 'hush', autoLogin: false, email: '',
-    authSecret: 'hush-lastpass-master-password', refresh: false, names: [],
-  };
+  const result = { every: '6h', group: 'hush', names: [] };
   while (args.length) {
     const arg = args.shift();
     if (arg === '--every') result.every = args.shift() || die('--every needs an interval');
     else if (arg === '--group') result.group = args.shift() || die('--group needs a path');
-    else if (arg === '--email') result.email = args.shift() || die('--email needs an address');
-    else if (arg === '--auth-secret') result.authSecret = args.shift() || die('--auth-secret needs a name');
-    else if (arg === '--auto-login') result.autoLogin = true;
-    else if (arg === '--refresh-login-secret') result.refresh = true;
     else if (arg === '--') { result.names.push(...args); break; }
     else if (arg.startsWith('-')) die(`unknown option '${arg}'`);
     else result.names.push(arg);
   }
   if (!result.group || result.group.endsWith('/')) die('--group must be non-empty and cannot end with /');
-  if (result.autoLogin && !result.email) die('--email is required with --auto-login');
-  if (result.refresh && !result.autoLogin) die('--refresh-login-secret requires --auto-login');
   result.seconds = seconds(result.every);
   return result;
 }
 
 function syncArgs(config, dryRun = false) {
   const args = ['sync', 'lastpass', '--group', config.group];
-  if (config.autoLogin) args.push('--exclude', config.authSecret);
   if (dryRun) args.push('--dry-run');
   args.push(...config.names);
   return args;
@@ -140,25 +125,8 @@ function install(args) {
   const lpass = findExecutable('lpass', process.env.HUSH_LASTPASS_SCHEDULE_LPASS);
   const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
 
-  if (options.autoLogin) {
-    process.stdout.write('hush-lastpass-schedule: auto-login opt-in stores your LastPass master password in the local hush store.\n');
-    const login = run(lpass, ['login', '--trust', options.email], {
-      stdio: 'inherit',
-      env: { ...process.env, LPASS_AGENT_TIMEOUT: '0' },
-    });
-    if (login.status !== 0) die('interactive trusted-device login failed; nothing installed');
-
-    const listed = run(hush, ['list']);
-    const hasSecret = listed.status === 0 && listed.stdout.split(/\r?\n/).includes(options.authSecret);
-    if (!hasSecret || options.refresh) {
-      process.stdout.write(`hush-lastpass-schedule: storing login material as hush secret '${options.authSecret}'.\n`);
-      const stored = run(hush, ['set', options.authSecret], { stdio: 'inherit' });
-      if (stored.status !== 0) die('login secret was not stored; nothing installed');
-    }
-  } else {
-    const status = run(lpass, ['status', '--quiet', '--color=never']);
-    if (status.status !== 0) die('LastPass is not logged in; run lpass login first or use --auto-login');
-  }
+  const status = run(lpass, ['status', '--quiet', '--color=never']);
+  if (status.status !== 0) die('LastPass is not logged in; run LPASS_AGENT_TIMEOUT=0 lpass login --trust <email> first');
 
   const config = {
     version: 1,
@@ -167,9 +135,6 @@ function install(args) {
     names: options.names,
     every: options.every,
     seconds: options.seconds,
-    autoLogin: options.autoLogin,
-    email: options.email,
-    authSecret: options.authSecret,
   };
 
   const preview = run(hush, syncArgs(config, true), { stdio: 'inherit' });
@@ -209,16 +174,7 @@ function install(args) {
 function scheduledRun(configPath) {
   const config = readConfig(configPath);
   if (run(config.lpass, ['status', '--quiet', '--color=never']).status !== 0) {
-    if (!config.autoLogin) die('LastPass is logged out and auto-login is disabled');
-    const env = {
-      ...process.env,
-      LPASS_AGENT_TIMEOUT: '0',
-      LPASS_DISABLE_PINENTRY: '1',
-    };
-    const login = run(config.hush, [
-      'pipe', config.authSecret, '--', config.lpass, 'login', '--trust', config.email,
-    ], { env });
-    if (login.status !== 0) die('automatic LastPass login failed; refresh trusted login interactively');
+    die('LastPass is logged out; run LPASS_AGENT_TIMEOUT=0 lpass login --trust <email> interactively');
   }
 
   const synced = run(config.hush, syncArgs(config));
@@ -231,7 +187,7 @@ function status() {
   const config = readConfig(paths.config);
   const launchctl = findExecutable('launchctl', process.env.HUSH_LASTPASS_SCHEDULE_LAUNCHCTL);
   const result = run(launchctl, ['print', `gui/${process.getuid()}/${LABEL}`]);
-  process.stdout.write(`hush-lastpass-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}, auto-login ${config.autoLogin ? 'enabled' : 'disabled'}\n`);
+  process.stdout.write(`hush-lastpass-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}\n`);
   process.exit(result.status === 0 ? 0 : 1);
 }
 

--- a/hush
+++ b/hush
@@ -189,6 +189,9 @@ hush — a secret store for AI agents. values are never printed.
                                    inject all secrets from a .hush manifest (ENVVAR=secret-name
                                    lines, optional first line ns=<namespace>), then exec <cmd>
   hush pipe <name> -- <cmd...>     stream the value to <cmd>'s stdin (e.g. wrangler secret put)
+  hush sync lastpass [options] [name ...]
+                                   upsert selected secrets into LastPass password fields. with no
+                                   names, sync all. options: --group <path> (default: hush), --dry-run
   hush file <name> <path>          write the value to a 0600 file (refuses inside a git repo)
   hush list                        list NAMES only, read straight from the store (never values)
   hush rename <old> <new> [--force]   (alias: mv)
@@ -300,6 +303,65 @@ case "$cmd" in
     shift; [ $# -gt 0 ] || die "pipe: no command after --"
     b_fetch "$name" __val
     printf '%s' "$__val" | "$@"; rc=$?; unset __val; exit $rc
+    ;;
+  sync)
+    backend_check
+    target="${1:-}"; [ -n "$target" ] || die "sync: missing target (supported: lastpass)"; shift
+    [ "$target" = lastpass ] || die "sync: unsupported target '$target' (supported: lastpass)"
+
+    group="hush"; dry_run=0; names=()
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --group)
+          [ $# -ge 2 ] || die "sync lastpass: --group needs a path"
+          group="$2"; shift 2 ;;
+        --dry-run) dry_run=1; shift ;;
+        --) shift; while [ $# -gt 0 ]; do names+=("$1"); shift; done ;;
+        -*) die "sync lastpass: unknown option '$1'" ;;
+        *) names+=("$1"); shift ;;
+      esac
+    done
+    [ -n "$group" ] || die "sync lastpass: --group cannot be empty"
+    case "$group" in *$'\n'*) die "sync lastpass: --group cannot contain a newline" ;; esac
+    [ "${group%/}" = "$group" ] || die "sync lastpass: --group cannot end with '/'"
+
+    lpass="${HUSH_LPASS:-lpass}"
+    command -v "$lpass" >/dev/null 2>&1 || die "sync lastpass: '$lpass' is required (install lastpass-cli, then run: lpass login <email>)"
+    "$lpass" status --quiet --color=never >/dev/null 2>&1 || die "sync lastpass: LastPass is not logged in (run: lpass login <email>)"
+
+    if [ "${#names[@]}" -eq 0 ]; then
+      while IFS= read -r name; do [ -n "$name" ] && names+=("$name"); done < <(b_list)
+    fi
+    [ "${#names[@]}" -gt 0 ] || die "sync lastpass: no hush secrets found in namespace '$NS'"
+
+    # Validate every local name before the first remote write. This catches selection mistakes
+    # without leaving a half-updated LastPass vault. Values are fetched only at the write boundary.
+    for name in "${names[@]}"; do
+      [ -n "$name" ] || die "sync lastpass: secret names cannot be empty"
+      case "$name" in *$'\n'*) die "sync lastpass: secret names cannot contain a newline" ;; esac
+      b_exists "$name" || die "sync lastpass: no secret named '$name' (try: hush list)"
+    done
+
+    for name in "${names[@]}"; do
+      entry="$group/$name"
+      if [ "$dry_run" -eq 1 ]; then
+        printf 'hush: would sync %s -> LastPass %s (value not read).\n' "$name" "$entry"
+        continue
+      fi
+
+      b_fetch "$name" __val
+      # lpass's non-interactive password edit consumes one line. Refuse multiline values instead of
+      # silently truncating them. Suppress lpass output because hush owns this write path.
+      case "$__val" in
+        *$'\n'*) unset __val; die "sync lastpass: '$name' is multiline; LastPass CLI password edits accept one line, so nothing was written for this secret" ;;
+      esac
+      if ! printf '%s' "$__val" | "$lpass" edit --sync=now --non-interactive --password --color=never "$entry" >/dev/null 2>&1; then
+        unset __val
+        die "sync lastpass: LastPass rejected '$entry' (duplicate names, a read-only shared entry, or sync failure); no value was shown"
+      fi
+      unset __val
+      printf 'hush: synced %s -> LastPass %s (value not shown).\n' "$name" "$entry"
+    done
     ;;
   file)
     backend_check

--- a/hush
+++ b/hush
@@ -69,8 +69,15 @@ b_exists() {
 b_store() {
   local name="$1" value="$2"
   case "$BACKEND" in
-    mac)     security add-generic-password -U -a "$name" -s "$(svc "$name")" -w "$value" >/dev/null 2>&1 \
-               || die "keychain store failed for '$name'" ;;
+    mac)
+      # A bare trailing -w makes security prompt on stdin, keeping ordinary values out of argv.
+      # Its prompt protocol is line-oriented, so preserve the legacy argv path for multiline data.
+      case "$value" in
+        *$'\n'*) security add-generic-password -U -a "$name" -s "$(svc "$name")" -w "$value" >/dev/null 2>&1 ;;
+        *)       printf '%s\n%s\n' "$value" "$value" \
+                   | security add-generic-password -U -a "$name" -s "$(svc "$name")" -w >/dev/null 2>&1 ;;
+      esac || die "keychain store failed for '$name'"
+      ;;
     linux)   printf '%s' "$value" | secret-tool store --label="$(svc "$name")" hush "$NS" name "$name" >/dev/null 2>&1 \
                || die "secret-tool store failed for '$name'" ;;
     windows) printf '%s' "$value" | winps store "$name" >/dev/null 2>&1 \
@@ -191,7 +198,8 @@ hush — a secret store for AI agents. values are never printed.
   hush pipe <name> -- <cmd...>     stream the value to <cmd>'s stdin (e.g. wrangler secret put)
   hush sync lastpass [options] [name ...]
                                    upsert selected secrets into LastPass password fields. with no
-                                   names, sync all. options: --group <path> (default: hush), --dry-run
+                                   names, sync all. options: --group <path> (default: hush),
+                                   --exclude <name> (repeatable), --dry-run
   hush file <name> <path>          write the value to a 0600 file (refuses inside a git repo)
   hush list                        list NAMES only, read straight from the store (never values)
   hush rename <old> <new> [--force]   (alias: mv)
@@ -309,12 +317,15 @@ case "$cmd" in
     target="${1:-}"; [ -n "$target" ] || die "sync: missing target (supported: lastpass)"; shift
     [ "$target" = lastpass ] || die "sync: unsupported target '$target' (supported: lastpass)"
 
-    group="hush"; dry_run=0; names=()
+    group="hush"; dry_run=0; names=(); excludes=()
     while [ $# -gt 0 ]; do
       case "$1" in
         --group)
           [ $# -ge 2 ] || die "sync lastpass: --group needs a path"
           group="$2"; shift 2 ;;
+        --exclude)
+          [ $# -ge 2 ] || die "sync lastpass: --exclude needs a secret name"
+          excludes+=("$2"); shift 2 ;;
         --dry-run) dry_run=1; shift ;;
         --) shift; while [ $# -gt 0 ]; do names+=("$1"); shift; done ;;
         -*) die "sync lastpass: unknown option '$1'" ;;
@@ -324,6 +335,12 @@ case "$cmd" in
     [ -n "$group" ] || die "sync lastpass: --group cannot be empty"
     case "$group" in *$'\n'*) die "sync lastpass: --group cannot contain a newline" ;; esac
     [ "${group%/}" = "$group" ] || die "sync lastpass: --group cannot end with '/'"
+    if [ "${#excludes[@]}" -gt 0 ]; then
+      for excluded in "${excludes[@]}"; do
+        [ -n "$excluded" ] || die "sync lastpass: --exclude cannot be empty"
+        case "$excluded" in *$'\n'*) die "sync lastpass: --exclude cannot contain a newline" ;; esac
+      done
+    fi
 
     lpass="${HUSH_LPASS:-lpass}"
     command -v "$lpass" >/dev/null 2>&1 || die "sync lastpass: '$lpass' is required (install lastpass-cli, then run: lpass login <email>)"
@@ -333,6 +350,20 @@ case "$cmd" in
       while IFS= read -r name; do [ -n "$name" ] && names+=("$name"); done < <(b_list)
     fi
     [ "${#names[@]}" -gt 0 ] || die "sync lastpass: no hush secrets found in namespace '$NS'"
+
+    selected=()
+    for name in "${names[@]}"; do
+      skip=0
+      if [ "${#excludes[@]}" -gt 0 ]; then
+        for excluded in "${excludes[@]}"; do [ "$name" = "$excluded" ] && skip=1; done
+      fi
+      [ "$skip" -eq 1 ] || selected+=("$name")
+    done
+    if [ "${#selected[@]}" -eq 0 ]; then
+      printf 'hush: no LastPass sync candidates remain after exclusions.\n'
+      exit 0
+    fi
+    names=("${selected[@]}")
 
     # Validate every local name before the first remote write. This catches selection mistakes
     # without leaving a half-updated LastPass vault. Values are fetched only at the write boundary.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@royashbrook/hush",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "a secret store for AI agents with one rule: the agent never sees the plaintext. get a secret once into the OS keychain, then inject it into commands forever. no get, cross-platform, MIT.",
   "bin": {
     "hush": "hush"

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "1.4.0",
   "description": "a secret store for AI agents with one rule: the agent never sees the plaintext. get a secret once into the OS keychain, then inject it into commands forever. no get, cross-platform, MIT.",
   "bin": {
-    "hush": "hush"
+    "hush": "hush",
+    "hush-lastpass-schedule": "helpers/hush-lastpass-schedule.mjs"
   },
   "files": [
     "hush",
+    "helpers/hush-lastpass-schedule.mjs",
     "win/hush-backend.ps1",
     "SKILL.md",
     "AGENTS.md"

--- a/test/lastpass-schedule.mjs
+++ b/test/lastpass-schedule.mjs
@@ -12,7 +12,6 @@ const helper = join(repo, 'helpers', 'hush-lastpass-schedule.mjs');
 const root = mkdtempSync(join(tmpdir(), 'hush-lastpass-schedule-'));
 const log = join(root, 'commands.log');
 const lpassState = join(root, 'lpass.logged-in');
-const secretState = join(root, 'hush.auth-stored');
 const launchState = join(root, 'launch.loaded');
 const hush = join(root, 'hush');
 const lpass = join(root, 'lpass');
@@ -27,18 +26,12 @@ script(lpass, `
 printf 'lpass:%s\\n' "$*" >> "$HUSH_TEST_LOG"
 case "\${1:-}" in
   status) [ -f "$HUSH_TEST_LPASS_STATE" ] ;;
-  login) : > "$HUSH_TEST_LPASS_STATE" ;;
   *) exit 41 ;;
 esac`);
 
 script(hush, `
 printf 'hush:%s\\n' "$*" >> "$HUSH_TEST_LOG"
 case "\${1:-}" in
-  list) [ -f "$HUSH_TEST_SECRET_STATE" ] && printf 'hush-lastpass-master-password\\n'; exit 0 ;;
-  set) : > "$HUSH_TEST_SECRET_STATE" ;;
-  pipe)
-    printf 'login-env:%s:%s\\n' "\${LPASS_AGENT_TIMEOUT:-}" "\${LPASS_DISABLE_PINENTRY:-}" >> "$HUSH_TEST_LOG"
-    exit "\${HUSH_TEST_PIPE_RC:-0}" ;;
   sync) exit "\${HUSH_TEST_SYNC_RC:-0}" ;;
   *) exit 42 ;;
 esac`);
@@ -61,7 +54,6 @@ const env = {
   HUSH_LASTPASS_SCHEDULE_LAUNCHCTL: launchctl,
   HUSH_TEST_LOG: log,
   HUSH_TEST_LPASS_STATE: lpassState,
-  HUSH_TEST_SECRET_STATE: secretState,
   HUSH_TEST_LAUNCH_STATE: launchState,
 };
 
@@ -75,19 +67,16 @@ function invoke(args, extraEnv = {}) {
 function ok(label) { process.stdout.write(`ok   - ${label}\n`); }
 
 try {
+  writeFileSync(lpassState, '');
   let result = invoke([
-    'install', '--auto-login', '--email', 'user@example.com', '--every', '6h',
-    '--group', 'team/hush', 'selected-a',
+    'install', '--every', '6h', '--group', 'team/hush', 'selected-a',
   ]);
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  ok('auto-login schedule installs');
+  ok('logged-in schedule installs');
 
   const configPath = join(root, 'Library', 'Application Support', 'hush', 'lastpass-schedule.json');
   const plistPath = join(root, 'Library', 'LaunchAgents', 'com.royashbrook.hush.lastpass-sync.plist');
   const config = JSON.parse(readFileSync(configPath, 'utf8'));
-  assert.equal(config.autoLogin, true);
-  assert.equal(config.email, 'user@example.com');
-  assert.equal(config.authSecret, 'hush-lastpass-master-password');
   assert.deepEqual(config.names, ['selected-a']);
   assert.equal(config.seconds, 21600);
   assert.equal(statSync(configPath).mode & 0o777, 0o600);
@@ -97,31 +86,34 @@ try {
   const plist = readFileSync(plistPath, 'utf8');
   assert.match(plist, /<integer>21600<\/integer>/);
   assert.match(plist, /<string>run<\/string>/);
-  assert.ok(!plist.includes('user@example.com'));
-  assert.ok(!plist.includes('hush-lastpass-master-password'));
   ok('LaunchAgent contains only runner and config paths');
 
   let commands = readFileSync(log, 'utf8');
-  assert.match(commands, /lpass:login --trust user@example\.com/);
-  assert.match(commands, /hush:set hush-lastpass-master-password/);
-  assert.match(commands, /hush:sync lastpass --group team\/hush --exclude hush-lastpass-master-password --dry-run selected-a/);
+  assert.match(commands, /lpass:status --quiet --color=never/);
+  assert.match(commands, /hush:sync lastpass --group team\/hush --dry-run selected-a/);
   assert.match(commands, /launchctl:bootstrap gui\/\d+ /);
-  ok('install performs trusted login, stores auth, previews, then loads');
+  ok('install checks login, previews, then loads');
 
   unlinkSync(lpassState);
   writeFileSync(log, '');
   result = invoke(['run']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /LastPass is logged out/);
+  commands = readFileSync(log, 'utf8');
+  assert.ok(!commands.includes('hush:sync'));
+  ok('logged-out run fails before sync');
+
+  writeFileSync(lpassState, '');
+  writeFileSync(log, '');
+  result = invoke(['run']);
   assert.equal(result.status, 0, result.stderr || result.stdout);
   commands = readFileSync(log, 'utf8');
-  assert.match(commands, /hush:pipe hush-lastpass-master-password -- .*lpass login --trust user@example\.com/);
-  assert.match(commands, /login-env:0:1/);
-  assert.match(commands, /hush:sync lastpass --group team\/hush --exclude hush-lastpass-master-password selected-a/);
-  assert.ok(!commands.includes('master-password-value'));
-  ok('logged-out run reauthenticates from hush and excludes auth secret');
+  assert.match(commands, /hush:sync lastpass --group team\/hush selected-a/);
+  ok('logged-in run syncs selected names');
 
   result = invoke(['status']);
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /loaded, every 6h, auto-login enabled/);
+  assert.match(result.stdout, /loaded, every 6h/);
   ok('status reports loaded schedule');
 
   result = invoke(['remove']);
@@ -132,8 +124,8 @@ try {
 
   result = invoke(['install', '--auto-login', '--every', '6h']);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /--email is required/);
-  ok('auto-login requires explicit email opt-in');
+  assert.match(result.stderr, /unknown option '--auto-login'/);
+  ok('unsupported auto-login is rejected');
 
   process.stdout.write('# LastPass schedule tests done. failures: 0\n');
 } finally {

--- a/test/lastpass-schedule.mjs
+++ b/test/lastpass-schedule.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repo = fileURLToPath(new URL('..', import.meta.url));
+const helper = join(repo, 'helpers', 'hush-lastpass-schedule.mjs');
+const root = mkdtempSync(join(tmpdir(), 'hush-lastpass-schedule-'));
+const log = join(root, 'commands.log');
+const lpassState = join(root, 'lpass.logged-in');
+const secretState = join(root, 'hush.auth-stored');
+const launchState = join(root, 'launch.loaded');
+const hush = join(root, 'hush');
+const lpass = join(root, 'lpass');
+const launchctl = join(root, 'launchctl');
+
+function script(path, content) {
+  writeFileSync(path, `#!/usr/bin/env bash\nset -u\n${content}\n`, { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+script(lpass, `
+printf 'lpass:%s\\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  status) [ -f "$HUSH_TEST_LPASS_STATE" ] ;;
+  login) : > "$HUSH_TEST_LPASS_STATE" ;;
+  *) exit 41 ;;
+esac`);
+
+script(hush, `
+printf 'hush:%s\\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  list) [ -f "$HUSH_TEST_SECRET_STATE" ] && printf 'hush-lastpass-master-password\\n'; exit 0 ;;
+  set) : > "$HUSH_TEST_SECRET_STATE" ;;
+  pipe)
+    printf 'login-env:%s:%s\\n' "\${LPASS_AGENT_TIMEOUT:-}" "\${LPASS_DISABLE_PINENTRY:-}" >> "$HUSH_TEST_LOG"
+    exit "\${HUSH_TEST_PIPE_RC:-0}" ;;
+  sync) exit "\${HUSH_TEST_SYNC_RC:-0}" ;;
+  *) exit 42 ;;
+esac`);
+
+script(launchctl, `
+printf 'launchctl:%s\\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  bootstrap) : > "$HUSH_TEST_LAUNCH_STATE" ;;
+  bootout) rm -f "$HUSH_TEST_LAUNCH_STATE" ;;
+  print) [ -f "$HUSH_TEST_LAUNCH_STATE" ] ;;
+  *) exit 43 ;;
+esac`);
+
+const env = {
+  ...process.env,
+  HUSH_LASTPASS_SCHEDULE_HOME: root,
+  HUSH_LASTPASS_SCHEDULE_PLATFORM: 'darwin',
+  HUSH_LASTPASS_SCHEDULE_HUSH: hush,
+  HUSH_LASTPASS_SCHEDULE_LPASS: lpass,
+  HUSH_LASTPASS_SCHEDULE_LAUNCHCTL: launchctl,
+  HUSH_TEST_LOG: log,
+  HUSH_TEST_LPASS_STATE: lpassState,
+  HUSH_TEST_SECRET_STATE: secretState,
+  HUSH_TEST_LAUNCH_STATE: launchState,
+};
+
+function invoke(args, extraEnv = {}) {
+  return spawnSync(process.execPath, [helper, ...args], {
+    env: { ...env, ...extraEnv },
+    encoding: 'utf8',
+  });
+}
+
+function ok(label) { process.stdout.write(`ok   - ${label}\n`); }
+
+try {
+  let result = invoke([
+    'install', '--auto-login', '--email', 'user@example.com', '--every', '6h',
+    '--group', 'team/hush', 'selected-a',
+  ]);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  ok('auto-login schedule installs');
+
+  const configPath = join(root, 'Library', 'Application Support', 'hush', 'lastpass-schedule.json');
+  const plistPath = join(root, 'Library', 'LaunchAgents', 'com.royashbrook.hush.lastpass-sync.plist');
+  const config = JSON.parse(readFileSync(configPath, 'utf8'));
+  assert.equal(config.autoLogin, true);
+  assert.equal(config.email, 'user@example.com');
+  assert.equal(config.authSecret, 'hush-lastpass-master-password');
+  assert.deepEqual(config.names, ['selected-a']);
+  assert.equal(config.seconds, 21600);
+  assert.equal(statSync(configPath).mode & 0o777, 0o600);
+  assert.ok(!readFileSync(configPath, 'utf8').includes('master-password-value'));
+  ok('config contains metadata only and is mode 0600');
+
+  const plist = readFileSync(plistPath, 'utf8');
+  assert.match(plist, /<integer>21600<\/integer>/);
+  assert.match(plist, /<string>run<\/string>/);
+  assert.ok(!plist.includes('user@example.com'));
+  assert.ok(!plist.includes('hush-lastpass-master-password'));
+  ok('LaunchAgent contains only runner and config paths');
+
+  let commands = readFileSync(log, 'utf8');
+  assert.match(commands, /lpass:login --trust user@example\.com/);
+  assert.match(commands, /hush:set hush-lastpass-master-password/);
+  assert.match(commands, /hush:sync lastpass --group team\/hush --exclude hush-lastpass-master-password --dry-run selected-a/);
+  assert.match(commands, /launchctl:bootstrap gui\/\d+ /);
+  ok('install performs trusted login, stores auth, previews, then loads');
+
+  unlinkSync(lpassState);
+  writeFileSync(log, '');
+  result = invoke(['run']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  commands = readFileSync(log, 'utf8');
+  assert.match(commands, /hush:pipe hush-lastpass-master-password -- .*lpass login --trust user@example\.com/);
+  assert.match(commands, /login-env:0:1/);
+  assert.match(commands, /hush:sync lastpass --group team\/hush --exclude hush-lastpass-master-password selected-a/);
+  assert.ok(!commands.includes('master-password-value'));
+  ok('logged-out run reauthenticates from hush and excludes auth secret');
+
+  result = invoke(['status']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /loaded, every 6h, auto-login enabled/);
+  ok('status reports loaded schedule');
+
+  result = invoke(['remove']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(existsSync(plistPath), false);
+  assert.equal(existsSync(configPath), true);
+  ok('remove unloads schedule and retains non-secret config');
+
+  result = invoke(['install', '--auto-login', '--every', '6h']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /--email is required/);
+  ok('auto-login requires explicit email opt-in');
+
+  process.stdout.write('# LastPass schedule tests done. failures: 0\n');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/test/lastpass-schedule.mjs
+++ b/test/lastpass-schedule.mjs
@@ -12,6 +12,7 @@ const helper = join(repo, 'helpers', 'hush-lastpass-schedule.mjs');
 const root = mkdtempSync(join(tmpdir(), 'hush-lastpass-schedule-'));
 const log = join(root, 'commands.log');
 const lpassState = join(root, 'lpass.logged-in');
+const secretState = join(root, 'hush.auth-stored');
 const launchState = join(root, 'launch.loaded');
 const hush = join(root, 'hush');
 const lpass = join(root, 'lpass');
@@ -26,12 +27,18 @@ script(lpass, `
 printf 'lpass:%s\\n' "$*" >> "$HUSH_TEST_LOG"
 case "\${1:-}" in
   status) [ -f "$HUSH_TEST_LPASS_STATE" ] ;;
+  login) : > "$HUSH_TEST_LPASS_STATE" ;;
   *) exit 41 ;;
 esac`);
 
 script(hush, `
 printf 'hush:%s\\n' "$*" >> "$HUSH_TEST_LOG"
 case "\${1:-}" in
+  list) [ -f "$HUSH_TEST_SECRET_STATE" ] && printf 'hush-lastpass-master-password\\n'; exit 0 ;;
+  set) : > "$HUSH_TEST_SECRET_STATE" ;;
+  pipe)
+    printf 'login-env:%s:%s\\n' "\${LPASS_AGENT_TIMEOUT:-}" "\${LPASS_DISABLE_PINENTRY:-}" >> "$HUSH_TEST_LOG"
+    exit "\${HUSH_TEST_PIPE_RC:-0}" ;;
   sync) exit "\${HUSH_TEST_SYNC_RC:-0}" ;;
   *) exit 42 ;;
 esac`);
@@ -54,6 +61,7 @@ const env = {
   HUSH_LASTPASS_SCHEDULE_LAUNCHCTL: launchctl,
   HUSH_TEST_LOG: log,
   HUSH_TEST_LPASS_STATE: lpassState,
+  HUSH_TEST_SECRET_STATE: secretState,
   HUSH_TEST_LAUNCH_STATE: launchState,
 };
 
@@ -67,16 +75,19 @@ function invoke(args, extraEnv = {}) {
 function ok(label) { process.stdout.write(`ok   - ${label}\n`); }
 
 try {
-  writeFileSync(lpassState, '');
   let result = invoke([
-    'install', '--every', '6h', '--group', 'team/hush', 'selected-a',
+    'install', '--auto-login', '--email', 'user@example.com', '--every', '6h',
+    '--group', 'team/hush', 'selected-a',
   ]);
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  ok('logged-in schedule installs');
+  ok('auto-login schedule installs');
 
   const configPath = join(root, 'Library', 'Application Support', 'hush', 'lastpass-schedule.json');
   const plistPath = join(root, 'Library', 'LaunchAgents', 'com.royashbrook.hush.lastpass-sync.plist');
   const config = JSON.parse(readFileSync(configPath, 'utf8'));
+  assert.equal(config.autoLogin, true);
+  assert.equal(config.email, 'user@example.com');
+  assert.equal(config.authSecret, 'hush-lastpass-master-password');
   assert.deepEqual(config.names, ['selected-a']);
   assert.equal(config.seconds, 21600);
   assert.equal(statSync(configPath).mode & 0o777, 0o600);
@@ -86,34 +97,31 @@ try {
   const plist = readFileSync(plistPath, 'utf8');
   assert.match(plist, /<integer>21600<\/integer>/);
   assert.match(plist, /<string>run<\/string>/);
+  assert.ok(!plist.includes('user@example.com'));
+  assert.ok(!plist.includes('hush-lastpass-master-password'));
   ok('LaunchAgent contains only runner and config paths');
 
   let commands = readFileSync(log, 'utf8');
-  assert.match(commands, /lpass:status --quiet --color=never/);
-  assert.match(commands, /hush:sync lastpass --group team\/hush --dry-run selected-a/);
+  assert.match(commands, /lpass:login --trust user@example\.com/);
+  assert.match(commands, /hush:set hush-lastpass-master-password/);
+  assert.match(commands, /hush:sync lastpass --group team\/hush --exclude hush-lastpass-master-password --dry-run selected-a/);
   assert.match(commands, /launchctl:bootstrap gui\/\d+ /);
-  ok('install checks login, previews, then loads');
+  ok('install performs trusted login, stores auth, previews, then loads');
 
   unlinkSync(lpassState);
   writeFileSync(log, '');
   result = invoke(['run']);
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /LastPass is logged out/);
-  commands = readFileSync(log, 'utf8');
-  assert.ok(!commands.includes('hush:sync'));
-  ok('logged-out run fails before sync');
-
-  writeFileSync(lpassState, '');
-  writeFileSync(log, '');
-  result = invoke(['run']);
   assert.equal(result.status, 0, result.stderr || result.stdout);
   commands = readFileSync(log, 'utf8');
-  assert.match(commands, /hush:sync lastpass --group team\/hush selected-a/);
-  ok('logged-in run syncs selected names');
+  assert.match(commands, /hush:pipe hush-lastpass-master-password -- .*lpass login --trust user@example\.com/);
+  assert.match(commands, /login-env:0:1/);
+  assert.match(commands, /hush:sync lastpass --group team\/hush --exclude hush-lastpass-master-password selected-a/);
+  assert.ok(!commands.includes('master-password-value'));
+  ok('logged-out run reauthenticates from hush and excludes auth secret');
 
   result = invoke(['status']);
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.match(result.stdout, /loaded, every 6h/);
+  assert.match(result.stdout, /loaded, every 6h, auto-login enabled/);
   ok('status reports loaded schedule');
 
   result = invoke(['remove']);
@@ -124,8 +132,8 @@ try {
 
   result = invoke(['install', '--auto-login', '--every', '6h']);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /unknown option '--auto-login'/);
-  ok('unsupported auto-login is rejected');
+  assert.match(result.stderr, /--email is required/);
+  ok('auto-login requires explicit email opt-in');
 
   process.stdout.write('# LastPass schedule tests done. failures: 0\n');
 } finally {

--- a/test/lastpass-sync.sh
+++ b/test/lastpass-sync.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Deterministic LastPass sync tests. Both the OS store and lpass are fakes, so this never touches a
+# real keychain or vault. The sentinel is test data and is never written to the command log/output.
+set -uo pipefail
+
+HUSH="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)/hush"
+STUB="$(mktemp -d 2>/dev/null || echo "${TMPDIR:-/tmp}/hush-lastpass-test-$$")"
+STORE="$STUB/store"
+export HUSH_TEST_STORE="$STORE"
+export HUSH_TEST_SECURITY_LOG="$STUB/security.log"
+export HUSH_LPASS_LOG="$STUB/lpass.log"
+export HUSH_NS="hush-lastpass-test-$$"
+export HUSH_LPASS="$STUB/lpass"
+SENTINEL="LP-S3NT-$$-never-log-this"
+fails=0
+
+mkdir -p "$STORE"
+cleanup() { rm -rf "$STUB" 2>/dev/null; }
+trap cleanup EXIT
+ok()  { printf 'ok   - %s\n' "$1"; }
+bad() { printf 'FAIL - %s\n' "$1"; fails=$((fails + 1)); }
+run_hush() { env PATH="$STUB:$PATH" "$HUSH" "$@"; }
+
+printf '%s\n' '#!/bin/sh' \
+  'if [ "${1:-}" = -s ]; then printf "Darwin\n"; else /usr/bin/uname "$@"; fi' > "$STUB/uname"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -u' \
+  'verb="${1:-}"; shift || true' \
+  'service=""; value=""; show=0' \
+  'while [ $# -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -s) service="$2"; shift 2 ;;' \
+  '    -w) if [ $# -gt 1 ]; then value="$2"; shift 2; else show=1; shift; fi ;;' \
+  '    *) shift ;;' \
+  '  esac' \
+  'done' \
+  'case "$verb" in' \
+  '  add-generic-password) printf "%s" "$value" > "$HUSH_TEST_STORE/$service" ;;' \
+  '  find-generic-password)' \
+  '    [ -f "$HUSH_TEST_STORE/$service" ] || exit 44' \
+  '    if [ "$show" -eq 1 ]; then printf "fetch\n" >> "$HUSH_TEST_SECURITY_LOG"; cat "$HUSH_TEST_STORE/$service"; fi' \
+  '    exit 0' \
+  '    ;;' \
+  '  delete-generic-password) rm -f "$HUSH_TEST_STORE/$service" ;;' \
+  '  dump-keychain)' \
+  '    for item in "$HUSH_TEST_STORE"/*; do' \
+  '      [ -f "$item" ] || continue' \
+  "      printf '    \"svce\"<blob>=\"%s\"\\n' \"\${item##*/}\"" \
+  '    done' \
+  '    ;;' \
+  '  *) exit 45 ;;' \
+  'esac' > "$STUB/security"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -u' \
+  'printf "%s\n" "$*" >> "$HUSH_LPASS_LOG"' \
+  'case "$1" in' \
+  '  status) exit "${HUSH_LPASS_STATUS_RC:-0}" ;;' \
+  '  edit)' \
+  '    value="$(cat)"' \
+  '    [ -n "$value" ] || exit 41' \
+  '    if [ "${HUSH_LPASS_EXPECT+x}" = x ] && [ "$value" != "$HUSH_LPASS_EXPECT" ]; then exit 42; fi' \
+  '    printf "value-ok\n" >> "$HUSH_LPASS_LOG"' \
+  '    exit "${HUSH_LPASS_EDIT_RC:-0}" ;;' \
+  '  *) exit 43 ;;' \
+  'esac' > "$STUB/lpass"
+chmod +x "$STUB/uname" "$STUB/security" "$STUB/lpass"
+
+printf '%s' "$SENTINEL" | run_hush set sync-a --pipe >/dev/null 2>&1
+run_hush mint sync-b --bytes 4 >/dev/null 2>&1
+
+: > "$HUSH_LPASS_LOG"
+out="$(HUSH_LPASS_EXPECT="$SENTINEL" run_hush sync lastpass --group team/secrets sync-a 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "selected secret syncs" || bad "selected sync failed (got: $out)"
+printf '%s' "$out" | grep -qF "$SENTINEL" && bad "secret leaked in success output" || ok "success output does not leak"
+grep -qx 'status --quiet --color=never' "$HUSH_LPASS_LOG" && ok "login checked first" || bad "login check missing"
+grep -qx 'edit --sync=now --non-interactive --password --color=never team/secrets/sync-a' "$HUSH_LPASS_LOG" && ok "safe upsert argv" || bad "upsert argv wrong"
+grep -qx 'value-ok' "$HUSH_LPASS_LOG" && ok "value arrives on stdin" || bad "stdin value mismatch"
+grep -qF "$SENTINEL" "$HUSH_LPASS_LOG" && bad "secret reached LastPass argv/log" || ok "secret stays out of LastPass argv/log"
+
+: > "$HUSH_LPASS_LOG"
+: > "$HUSH_TEST_SECURITY_LOG"
+out="$(run_hush sync lastpass --dry-run sync-a 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "dry-run succeeds" || bad "dry-run failed (got: $out)"
+grep -q '^edit ' "$HUSH_LPASS_LOG" && bad "dry-run wrote remotely" || ok "dry-run makes no write"
+printf '%s' "$out" | grep -q 'value not read' && ok "dry-run skips fetch" || bad "dry-run report missing"
+[ ! -s "$HUSH_TEST_SECURITY_LOG" ] && ok "dry-run performs no backend fetch" || bad "dry-run fetched a secret"
+
+: > "$HUSH_LPASS_LOG"
+listed="$(run_hush list 2>&1)"
+printf '%s\n' "$listed" | grep -qx 'sync-a' && printf '%s\n' "$listed" | grep -qx 'sync-b' && ok "fake store lists both names" || bad "fake store list mismatch (got: $listed)"
+out="$(run_hush sync lastpass 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "bulk sync succeeds" || bad "bulk sync failed (got: $out)"
+[ "$(grep -c '^edit ' "$HUSH_LPASS_LOG")" -eq 2 ] && ok "bulk sync selects all names" || bad "bulk selection wrong"
+grep -q 'hush/sync-a$' "$HUSH_LPASS_LOG" && grep -q 'hush/sync-b$' "$HUSH_LPASS_LOG" && ok "bulk destinations" || bad "bulk destinations wrong"
+
+: > "$HUSH_LPASS_LOG"
+out="$(HUSH_LPASS_STATUS_RC=1 run_hush sync lastpass sync-a 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "logged-out state fails" || bad "logged-out state accepted"
+grep -q '^edit ' "$HUSH_LPASS_LOG" && bad "write attempted while logged out" || ok "login failure precedes write"
+
+: > "$HUSH_LPASS_LOG"
+out="$(run_hush sync lastpass sync-a missing-name 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "missing selection fails" || bad "missing selection accepted"
+grep -q '^edit ' "$HUSH_LPASS_LOG" && bad "partial write before selection validation" || ok "all names validate before write"
+
+: > "$HUSH_LPASS_LOG"
+out="$(HUSH_LPASS_EXPECT="$SENTINEL" HUSH_LPASS_EDIT_RC=9 run_hush sync lastpass sync-a 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "remote rejection propagates" || bad "remote rejection ignored"
+printf '%s' "$out" | grep -qF "$SENTINEL" && bad "secret leaked in failure output" || ok "failure output does not leak"
+
+printf 'line one\nline two' | run_hush set sync-multiline --pipe >/dev/null 2>&1
+: > "$HUSH_LPASS_LOG"
+out="$(run_hush sync lastpass sync-multiline 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "multiline value is refused" || bad "multiline value was truncated"
+grep -q '^edit ' "$HUSH_LPASS_LOG" && bad "multiline value reached remote" || ok "multiline refusal precedes write"
+
+printf '# LastPass sync tests done. failures: %d\n' "$fails"
+[ "$fails" -eq 0 ]

--- a/test/lastpass-sync.sh
+++ b/test/lastpass-sync.sh
@@ -27,19 +27,29 @@ printf '%s\n' '#!/bin/sh' \
 printf '%s\n' '#!/usr/bin/env bash' \
   'set -u' \
   'verb="${1:-}"; shift || true' \
-  'service=""; value=""; show=0' \
+  'service=""; value=""; bare_w=0' \
   'while [ $# -gt 0 ]; do' \
   '  case "$1" in' \
   '    -s) service="$2"; shift 2 ;;' \
-  '    -w) if [ $# -gt 1 ]; then value="$2"; shift 2; else show=1; shift; fi ;;' \
+  '    -w) if [ $# -gt 1 ]; then value="$2"; shift 2; else bare_w=1; shift; fi ;;' \
   '    *) shift ;;' \
   '  esac' \
   'done' \
   'case "$verb" in' \
-  '  add-generic-password) printf "%s" "$value" > "$HUSH_TEST_STORE/$service" ;;' \
+  '  add-generic-password)' \
+  '    if [ "$bare_w" -eq 1 ]; then' \
+  '      IFS= read -r value || true' \
+  '      IFS= read -r confirm || true' \
+  '      [ "$value" = "$confirm" ] || exit 46' \
+  '      printf "prompt-store\n" >> "$HUSH_TEST_SECURITY_LOG"' \
+  '    else' \
+  '      printf "argv-store\n" >> "$HUSH_TEST_SECURITY_LOG"' \
+  '    fi' \
+  '    printf "%s" "$value" > "$HUSH_TEST_STORE/$service"' \
+  '    ;;' \
   '  find-generic-password)' \
   '    [ -f "$HUSH_TEST_STORE/$service" ] || exit 44' \
-  '    if [ "$show" -eq 1 ]; then printf "fetch\n" >> "$HUSH_TEST_SECURITY_LOG"; cat "$HUSH_TEST_STORE/$service"; fi' \
+  '    if [ "$bare_w" -eq 1 ]; then printf "fetch\n" >> "$HUSH_TEST_SECURITY_LOG"; cat "$HUSH_TEST_STORE/$service"; fi' \
   '    exit 0' \
   '    ;;' \
   '  delete-generic-password) rm -f "$HUSH_TEST_STORE/$service" ;;' \
@@ -69,6 +79,9 @@ chmod +x "$STUB/uname" "$STUB/security" "$STUB/lpass"
 
 printf '%s' "$SENTINEL" | run_hush set sync-a --pipe >/dev/null 2>&1
 run_hush mint sync-b --bytes 4 >/dev/null 2>&1
+printf '%s' 'login-only-test-value' | run_hush set sync-auth --pipe >/dev/null 2>&1
+grep -qF 'prompt-store' "$HUSH_TEST_SECURITY_LOG" && ok "single-line macOS stores use stdin prompt" || bad "single-line macOS store used argv"
+grep -qF 'argv-store' "$HUSH_TEST_SECURITY_LOG" && bad "single-line secret reached security argv" || ok "single-line secret stays out of security argv"
 
 : > "$HUSH_LPASS_LOG"
 out="$(HUSH_LPASS_EXPECT="$SENTINEL" run_hush sync lastpass --group team/secrets sync-a 2>&1)"; rc=$?
@@ -90,10 +103,16 @@ printf '%s' "$out" | grep -q 'value not read' && ok "dry-run skips fetch" || bad
 : > "$HUSH_LPASS_LOG"
 listed="$(run_hush list 2>&1)"
 printf '%s\n' "$listed" | grep -qx 'sync-a' && printf '%s\n' "$listed" | grep -qx 'sync-b' && ok "fake store lists both names" || bad "fake store list mismatch (got: $listed)"
-out="$(run_hush sync lastpass 2>&1)"; rc=$?
-[ "$rc" -eq 0 ] && ok "bulk sync succeeds" || bad "bulk sync failed (got: $out)"
-[ "$(grep -c '^edit ' "$HUSH_LPASS_LOG")" -eq 2 ] && ok "bulk sync selects all names" || bad "bulk selection wrong"
+out="$(run_hush sync lastpass --exclude sync-auth 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "bulk sync with exclusion succeeds" || bad "bulk exclusion failed (got: $out)"
+[ "$(grep -c '^edit ' "$HUSH_LPASS_LOG")" -eq 2 ] && ok "bulk sync selects all non-excluded names" || bad "bulk selection wrong"
 grep -q 'hush/sync-a$' "$HUSH_LPASS_LOG" && grep -q 'hush/sync-b$' "$HUSH_LPASS_LOG" && ok "bulk destinations" || bad "bulk destinations wrong"
+grep -q 'sync-auth$' "$HUSH_LPASS_LOG" && bad "excluded login secret reached LastPass" || ok "excluded login secret stays local"
+
+: > "$HUSH_LPASS_LOG"
+out="$(run_hush sync lastpass --exclude sync-auth sync-auth 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "all-excluded selection is a clean no-op" || bad "all-excluded selection failed"
+grep -q '^edit ' "$HUSH_LPASS_LOG" && bad "all-excluded selection wrote remotely" || ok "all-excluded selection makes no write"
 
 : > "$HUSH_LPASS_LOG"
 out="$(HUSH_LPASS_STATUS_RC=1 run_hush sync lastpass sync-a 2>&1)"; rc=$?

--- a/test/test.sh
+++ b/test/test.sh
@@ -127,5 +127,11 @@ else
   bad "isolated LastPass sync suite"
 fi
 
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/lastpass-schedule.mjs"; then
+  ok "isolated LastPass schedule suite"
+else
+  bad "isolated LastPass schedule suite"
+fi
+
 echo "# done. failures: $fails"
 [ "$fails" -eq 0 ]

--- a/test/test.sh
+++ b/test/test.sh
@@ -121,5 +121,11 @@ else
 fi
 "$HUSH" rm t-empty >/dev/null 2>&1; "$HUSH" rm t-x >/dev/null 2>&1
 
+if bash "$(dirname "${BASH_SOURCE[0]:-$0}")/lastpass-sync.sh"; then
+  ok "isolated LastPass sync suite"
+else
+  bad "isolated LastPass sync suite"
+fi
+
 echo "# done. failures: $fails"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
Adds one-way LastPass password-field upserts plus the npm-shipped macOS launchd helper. Auto-login remains explicitly experimental and documented as not live-tested because lastpass-cli crashes in the observed MFA flow. Deterministic sync, scheduler, argv, stdin, exclusion, and failure-path tests pass. Full macOS suite passes with Keychain access.\n\nCloses #6\nCloses #7