### PR TITLE
feat: add KeePassXC sync and iCloud scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ hush mint app-operator-key                    # generate + store a random one
 hush run TOKEN=my-vendor-token -- some-cmd    # inject into a command, never printed
 hush sync lastpass --dry-run                  # preview a one-way LastPass sync
 hush sync lastpass                            # upsert every name under LastPass group "hush"
+hush sync keepass --database vault.kdbx --db-secret keepass-password --dry-run
 hush list                                     # names only, never values
 ```
 
@@ -140,6 +141,53 @@ An API key cannot replace this login: the published [LastPass Business
 API](https://developer.lastpass.com/business/docs/index.md) manages accounts, companies, and
 reports, but does not expose vault-item writes. The scheduler is Node so other native schedulers can
 be added without changing the sync contract, but this release installs launchd on macOS only.
+
+## sync to a local KeePass database
+
+[KeePassXC](https://keepassxc.org/) opens the same encrypted KDBX file on macOS, Linux, and Windows.
+Put that file in an iCloud Drive folder and it becomes an offline-first backup that another iCloud
+machine can open without a service login:
+
+```sh
+brew install --cask keepassxc
+hush set hush-keepass-master-password
+hush sync keepass --database "$HOME/Library/Mobile Documents/com~apple~CloudDocs/hush/hush.kdbx" \
+  --db-secret hush-keepass-master-password --init
+```
+
+`--init` refuses to overwrite a file. Later runs omit it and upsert entries in group `hush`:
+
+```sh
+hush sync keepass --database "$HOME/Library/Mobile Documents/com~apple~CloudDocs/hush/hush.kdbx" \
+  --db-secret hush-keepass-master-password --dry-run
+hush sync keepass --database "$HOME/Library/Mobile Documents/com~apple~CloudDocs/hush/hush.kdbx" \
+  --db-secret hush-keepass-master-password --exclude local-only
+```
+
+The database password and entry passwords reach `keepassxc-cli` only over stdin. They are never put
+on argv, stdout, logs, or a temp plaintext file. The database-password secret is always excluded.
+Missing entries are created, unique entries are updated, duplicate names fail closed, and multiline
+values are refused rather than truncated.
+
+### schedule it into iCloud (macOS)
+
+The npm package includes a Node/launchd helper. A cold setup creates the database if absent, asks for
+its password through hush when needed, performs the first sync, and loads the recurring job:
+
+```sh
+npm install -g @royashbrook/hush
+brew install --cask keepassxc
+hush-keepass-schedule install --every 6h
+hush-keepass-schedule status
+```
+
+The default destination is `iCloud Drive/hush/hush.kdbx`. Use `--database`, `--db-secret`, `--group`,
+repeatable `--exclude`, or positional names to narrow it. `remove` unloads the LaunchAgent but keeps
+the database and mode-0600 metadata config.
+
+Keep one durable copy of the database password outside this KDBX. After a machine loss, the iCloud
+file cannot recover the hush secret that unlocks it. Treat one machine as the writer while iCloud is
+syncing to avoid conflicted KDBX copies.
 
 ## not a vault
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -114,6 +114,7 @@ hush run NAME=VAR [N2=V2 ...] -- <cmd>   # fetch into env vars, exec <cmd> (valu
 hush pipe <name> -- <cmd>                # stream the value to <cmd>'s stdin
 hush sync lastpass [name ...]            # upsert selected names, or all names when omitted
 hush sync lastpass --exclude <name>       # keep a local-only name out of bulk sync; repeatable
+hush sync keepass --database <file.kdbx> --db-secret <name> [name ...]
 hush list                                # NAMES only, never values
 hush rename <old> <new>                  # move to a new name (value moved INTERNALLY, never re-asked)
 hush rm   <name>                         # delete
@@ -156,6 +157,37 @@ stores the master password under
 failed setup installs nothing. A revoked or expired LastPass trust grant fails closed and requires
 interactive setup again. Without `--auto-login`, the helper schedules sync but requires an
 already-live `lpass` session. The helper currently installs a macOS LaunchAgent only.
+
+For an offline-first copy, sync into a KeePassXC KDBX file. The core command works anywhere both
+hush and `keepassxc-cli` run:
+
+```
+hush set hush-keepass-master-password
+hush sync keepass --database /path/to/hush.kdbx \
+  --db-secret hush-keepass-master-password --init
+hush sync keepass --database /path/to/hush.kdbx \
+  --db-secret hush-keepass-master-password --dry-run
+```
+
+`--init` refuses overwrite. Omit names to sync every secret except the database-password secret,
+use positional names for a subset, and repeat `--exclude <name>` for local-only values. Writes go to
+the password field under group `hush`. Values and the KDBX password travel only over stdin. Missing
+entries are created, unique entries are updated, duplicates fail closed, and multiline values are
+refused.
+
+On macOS, the npm package includes a Node helper that defaults to
+`iCloud Drive/hush/hush.kdbx` and installs a per-user LaunchAgent:
+
+```
+hush-keepass-schedule install --every 6h
+hush-keepass-schedule status
+hush-keepass-schedule remove
+```
+
+Install creates and populates an absent database. If the database-password secret does not exist,
+it invokes hush's hidden prompt. Keep a separate durable copy of that password, because a recovered
+KDBX cannot recover the local hush secret needed to open it. Avoid simultaneous writers while the
+file is syncing through iCloud.
 
 > **Escape hatch, `hush file <name> <path>`.** A few tools can *only* read a credential from a file
 > path (a service-account JSON, a cert, a kubeconfig). For those, and only those, `hush file` writes a
@@ -259,9 +291,9 @@ a sticky note.
 Treat it as an **on-ramp.** Two wins land immediately, even with no `hush exec` in sight: you can
 generate secrets securely from day one, and on an old project with values scattered across `.env`s,
 dashboards, and your head, a few pastes get them (a) centralized and (b) agent-usable from then on.
-For a durable, shareable home, **sync them onward** into a real secret manager. LastPass has a
-built-in one-way sync, and *extending hush* covers other CLIs and store backends. hush gets you
-consistent; the sync makes it permanent.
+For a durable, shareable home, **sync them onward**. LastPass and KeePassXC have built-in one-way
+sync targets, and *extending hush* covers other CLIs and store backends. hush gets you consistent;
+the sync makes it permanent.
 
 ## extending hush to the tools you already use
 
@@ -269,7 +301,7 @@ The friction this kills: *"go create this key, then paste it into GitHub / Wrang
 tell me when it's there."* If the agent already has the CLI for that tool, it shouldn't hand that
 back, it should just do it. Two directions:
 
-1. **Push a hush-held secret INTO another tool.** LastPass is built in as `hush sync lastpass`.
+1. **Push a hush-held secret INTO another tool.** LastPass and KeePassXC are built in as `hush sync` targets.
    Anything else with a CLI that takes the value on stdin is already a consumer via `pipe`:
    ```
    hush pipe deploy-token -- gh secret set DEPLOY_TOKEN          # into GitHub Actions

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -22,6 +22,27 @@ never used, failed setup installs nothing, and expired device trust fails closed
 the job but retains both config and the hush secret. The implementation is Node and stdlib-only; job
 installation currently targets macOS launchd.
 
+## hush-keepass-schedule, unattended local KDBX sync (macOS + iCloud)
+
+The npm package installs this Node helper beside `hush`. It creates or updates an encrypted KeePass
+database and schedules recurring sync with launchd:
+
+```sh
+brew install --cask keepassxc
+hush-keepass-schedule install --every 6h
+hush-keepass-schedule status
+hush-keepass-schedule remove
+```
+
+The default database is `iCloud Drive/hush/hush.kdbx`. Setup asks through hush for
+`hush-keepass-master-password` when absent, creates and populates an absent database, then stores
+only mode-0600 metadata in its config. Use `--database`, `--db-secret`, `--group`, repeatable
+`--exclude`, and positional secret names to change the selection.
+
+Database and entry passwords travel to `keepassxc-cli` only on stdin. The database-password secret
+is always excluded from sync. `remove` unloads launchd while retaining the KDBX and config. Keep a
+separate durable copy of the database password and avoid simultaneous iCloud writers.
+
 ## hush-backup, encrypted off-machine backup of the store (macOS + iCloud)
 
 A hush store lives only in the local OS keychain, so a wipe means re-provisioning every secret.

--- a/helpers/hush-keepass-schedule.mjs
+++ b/helpers/hush-keepass-schedule.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, delimiter, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const LABEL = 'com.royashbrook.hush.keepass-sync';
+const SCRIPT = fileURLToPath(import.meta.url);
+
+function die(message) {
+  process.stderr.write(`hush-keepass-schedule: ${message}\n`);
+  process.exit(1);
+}
+
+function usage(code = 0) {
+  const out = code ? process.stderr : process.stdout;
+  out.write(`hush-keepass-schedule, recurring hush -> KeePassXC sync
+
+  hush-keepass-schedule install [--every 6h] [options] [name ...]
+  hush-keepass-schedule run
+  hush-keepass-schedule status
+  hush-keepass-schedule remove
+
+options:
+  --database <file.kdbx>  destination (default: iCloud Drive/hush/hush.kdbx)
+  --db-secret <name>      hush name holding the database password
+                          (default: hush-keepass-master-password)
+  --group <name>          KeePass group (default: hush)
+  --exclude <name>        omit from bulk sync; repeatable
+  --every <Nm|Nh|Nd>      interval, minimum 5m (default: 6h)
+
+install creates the database when absent and prompts through hush if the database password secret
+does not exist. keep a separate durable copy of that password: the kdbx cannot recover itself.
+`);
+  process.exit(code);
+}
+
+function roots() {
+  const home = process.env.HUSH_KEEPASS_SCHEDULE_HOME || homedir();
+  return {
+    home,
+    config: join(home, 'Library', 'Application Support', 'hush', 'keepass-schedule.json'),
+    plist: join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`),
+    log: join(home, 'Library', 'Logs', 'hush-keepass-sync.log'),
+  };
+}
+
+function findExecutable(name, override) {
+  if (override) {
+    if (existsSync(override)) return override;
+    die(`configured ${name} executable does not exist: ${override}`);
+  }
+  for (const dir of (process.env.PATH || '').split(delimiter)) {
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  die(`${name} is not on PATH`);
+}
+
+function run(program, args, options = {}) {
+  return spawnSync(program, args, {
+    encoding: 'utf8',
+    env: options.env || process.env,
+    stdio: options.stdio || 'pipe',
+  });
+}
+
+function seconds(value) {
+  const match = /^(\d+)(m|h|d)$/.exec(value);
+  if (!match) die(`bad interval '${value}' (use Nm, Nh, or Nd)`);
+  const unit = { m: 60, h: 3600, d: 86400 }[match[2]];
+  const result = Number(match[1]) * unit;
+  if (result < 300) die('interval must be at least 5m');
+  return result;
+}
+
+function xml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function writeAtomic(path, value, mode = 0o600) {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temp = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`);
+  writeFileSync(temp, value, { mode });
+  renameSync(temp, path);
+}
+
+function expandPath(value, home) {
+  if (value === '~') return home;
+  if (value.startsWith('~/')) return join(home, value.slice(2));
+  return resolve(value);
+}
+
+function parseInstall(args, home) {
+  const result = {
+    database: join(home, 'Library', 'Mobile Documents', 'com~apple~CloudDocs', 'hush', 'hush.kdbx'),
+    dbSecret: 'hush-keepass-master-password',
+    group: 'hush', excludes: [], every: '6h', names: [],
+  };
+  while (args.length) {
+    const arg = args.shift();
+    if (arg === '--database') result.database = args.shift() || die('--database needs a path');
+    else if (arg === '--db-secret') result.dbSecret = args.shift() || die('--db-secret needs a name');
+    else if (arg === '--group') result.group = args.shift() || die('--group needs a name');
+    else if (arg === '--exclude') result.excludes.push(args.shift() || die('--exclude needs a name'));
+    else if (arg === '--every') result.every = args.shift() || die('--every needs an interval');
+    else if (arg === '--') { result.names.push(...args); break; }
+    else if (arg.startsWith('-')) die(`unknown option '${arg}'`);
+    else result.names.push(arg);
+  }
+  if (!result.database.endsWith('.kdbx')) die('--database must end in .kdbx');
+  if (!result.dbSecret) die('--db-secret must be non-empty');
+  if (!result.group || result.group.includes('/') || /[\r\n]/.test(result.group)) {
+    die('--group must be one non-empty group name');
+  }
+  result.database = expandPath(result.database, home);
+  result.seconds = seconds(result.every);
+  return result;
+}
+
+function syncArgs(config, mode = '') {
+  const args = [
+    'sync', 'keepass', '--database', config.database,
+    '--db-secret', config.dbSecret, '--group', config.group,
+  ];
+  for (const name of config.excludes) args.push('--exclude', name);
+  if (mode === 'init') args.push('--init');
+  else if (mode === 'dry-run') args.push('--dry-run');
+  args.push(...config.names);
+  return args;
+}
+
+function readConfig(path) {
+  if (!existsSync(path)) die(`no schedule config at ${path} (run install)`);
+  try { return JSON.parse(readFileSync(path, 'utf8')); }
+  catch { die(`could not read schedule config at ${path}`); }
+}
+
+function install(args) {
+  const platform = process.env.HUSH_KEEPASS_SCHEDULE_PLATFORM || process.platform;
+  if (platform !== 'darwin') die('schedule install currently supports macOS launchd only');
+  const paths = roots();
+  const options = parseInstall(args, paths.home);
+  const hush = findExecutable('hush', process.env.HUSH_KEEPASS_SCHEDULE_HUSH);
+  const keepassxc = findExecutable('keepassxc-cli', process.env.HUSH_KEEPASS_SCHEDULE_KEEPASSXC);
+  const launchctl = findExecutable('launchctl', process.env.HUSH_KEEPASS_SCHEDULE_LAUNCHCTL);
+  const config = {
+    version: 1, hush, keepassxc,
+    database: options.database, dbSecret: options.dbSecret, group: options.group,
+    excludes: options.excludes, names: options.names,
+    every: options.every, seconds: options.seconds,
+  };
+  const env = { ...process.env, HUSH_KEEPASSXC: keepassxc };
+
+  const listed = run(hush, ['list']);
+  const hasSecret = listed.status === 0 && listed.stdout.split(/\r?\n/).includes(config.dbSecret);
+  if (!hasSecret) {
+    process.stdout.write(`hush-keepass-schedule: create the KeePass database password as hush secret '${config.dbSecret}'.\n`);
+    const stored = run(hush, ['set', config.dbSecret], { stdio: 'inherit' });
+    if (stored.status !== 0) die('database password was not stored; nothing installed');
+  }
+
+  let mode = 'dry-run';
+  if (!existsSync(config.database)) {
+    try { mkdirSync(dirname(config.database), { recursive: true, mode: 0o700 }); }
+    catch { die(`could not create database directory: ${dirname(config.database)}`); }
+    mode = 'init';
+  }
+  const preview = run(hush, syncArgs(config, mode), { env, stdio: 'inherit' });
+  if (preview.status !== 0) die(`${mode === 'init' ? 'initial sync' : 'sync dry-run'} failed; nothing installed`);
+
+  writeAtomic(paths.config, `${JSON.stringify(config, null, 2)}\n`);
+  mkdirSync(dirname(paths.log), { recursive: true });
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xml(process.execPath)}</string>
+    <string>${xml(SCRIPT)}</string>
+    <string>run</string>
+    <string>--config</string>
+    <string>${xml(paths.config)}</string>
+  </array>
+  <key>StartInterval</key><integer>${config.seconds}</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>${xml(paths.log)}</string>
+  <key>StandardErrorPath</key><string>${xml(paths.log)}</string>
+</dict>
+</plist>
+`;
+  writeAtomic(paths.plist, plist);
+
+  const domain = `gui/${process.getuid()}`;
+  run(launchctl, ['bootout', domain, paths.plist]);
+  const loaded = run(launchctl, ['bootstrap', domain, paths.plist]);
+  if (loaded.status !== 0) die(`launchctl bootstrap failed; config and plist remain at ${paths.plist}`);
+  process.stdout.write(`hush-keepass-schedule: installed every ${config.every}. database: ${config.database}\n`);
+}
+
+function scheduledRun(configPath) {
+  const config = readConfig(configPath);
+  if (!existsSync(config.database)) die(`database is missing: ${config.database}`);
+  const env = { ...process.env, HUSH_KEEPASSXC: config.keepassxc };
+  const synced = run(config.hush, syncArgs(config), { env });
+  if (synced.status !== 0) die(`sync failed with exit ${synced.status}`);
+  process.stdout.write(`hush-keepass-schedule: ${new Date().toISOString()} sync ok\n`);
+}
+
+function status() {
+  const paths = roots();
+  const config = readConfig(paths.config);
+  const launchctl = findExecutable('launchctl', process.env.HUSH_KEEPASS_SCHEDULE_LAUNCHCTL);
+  const result = run(launchctl, ['print', `gui/${process.getuid()}/${LABEL}`]);
+  process.stdout.write(`hush-keepass-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}, database ${config.database}\n`);
+  process.exit(result.status === 0 ? 0 : 1);
+}
+
+function remove() {
+  const paths = roots();
+  const launchctl = findExecutable('launchctl', process.env.HUSH_KEEPASS_SCHEDULE_LAUNCHCTL);
+  run(launchctl, ['bootout', `gui/${process.getuid()}`, paths.plist]);
+  rmSync(paths.plist, { force: true });
+  process.stdout.write(`hush-keepass-schedule: removed LaunchAgent. database and config retained at ${paths.config}.\n`);
+}
+
+const [command = 'help', ...args] = process.argv.slice(2);
+if (command === 'install') install(args);
+else if (command === 'run') {
+  let config = roots().config;
+  if (args[0] === '--config' && args[1]) config = args[1];
+  scheduledRun(config);
+} else if (command === 'status') status();
+else if (command === 'remove') remove();
+else if (command === 'help' || command === '--help' || command === '-h') usage(0);
+else usage(2);

--- a/hush
+++ b/hush
@@ -200,6 +200,10 @@ hush — a secret store for AI agents. values are never printed.
                                    upsert selected secrets into LastPass password fields. with no
                                    names, sync all. options: --group <path> (default: hush),
                                    --exclude <name> (repeatable), --dry-run
+  hush sync keepass --database <file.kdbx> --db-secret <name> [options] [name ...]
+                                   upsert selected secrets into a KeePassXC database. with no names,
+                                   sync all except the database-password secret. options: --init,
+                                   --group <name> (default: hush), --exclude <name>, --dry-run
   hush file <name> <path>          write the value to a 0600 file (refuses inside a git repo)
   hush list                        list NAMES only, read straight from the store (never values)
   hush rename <old> <new> [--force]   (alias: mv)
@@ -314,9 +318,10 @@ case "$cmd" in
     ;;
   sync)
     backend_check
-    target="${1:-}"; [ -n "$target" ] || die "sync: missing target (supported: lastpass)"; shift
-    [ "$target" = lastpass ] || die "sync: unsupported target '$target' (supported: lastpass)"
+    target="${1:-}"; [ -n "$target" ] || die "sync: missing target (supported: lastpass, keepass)"; shift
+    case "$target" in lastpass|keepass) ;; *) die "sync: unsupported target '$target' (supported: lastpass, keepass)" ;; esac
 
+    if [ "$target" = lastpass ]; then
     group="hush"; dry_run=0; names=(); excludes=()
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -393,6 +398,146 @@ case "$cmd" in
       unset __val
       printf 'hush: synced %s -> LastPass %s (value not shown).\n' "$name" "$entry"
     done
+    else
+      database=""; db_secret=""; group="hush"; init=0; dry_run=0; names=(); excludes=()
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --database)
+            [ $# -ge 2 ] || die "sync keepass: --database needs a .kdbx path"
+            database="$2"; shift 2 ;;
+          --db-secret)
+            [ $# -ge 2 ] || die "sync keepass: --db-secret needs a hush secret name"
+            db_secret="$2"; shift 2 ;;
+          --group)
+            [ $# -ge 2 ] || die "sync keepass: --group needs a group name"
+            group="$2"; shift 2 ;;
+          --exclude)
+            [ $# -ge 2 ] || die "sync keepass: --exclude needs a secret name"
+            excludes+=("$2"); shift 2 ;;
+          --init) init=1; shift ;;
+          --dry-run) dry_run=1; shift ;;
+          --) shift; while [ $# -gt 0 ]; do names+=("$1"); shift; done ;;
+          -*) die "sync keepass: unknown option '$1'" ;;
+          *) names+=("$1"); shift ;;
+        esac
+      done
+
+      [ -n "$database" ] || die "sync keepass: --database is required"
+      case "$database" in *.kdbx) ;; *) die "sync keepass: --database must end in .kdbx" ;; esac
+      case "$database" in *$'\n'*) die "sync keepass: --database cannot contain a newline" ;; esac
+      [ -n "$db_secret" ] || die "sync keepass: --db-secret is required"
+      case "$db_secret" in *$'\n'*) die "sync keepass: --db-secret cannot contain a newline" ;; esac
+      [ -n "$group" ] || die "sync keepass: --group cannot be empty"
+      case "$group" in *$'\n'*|*/*) die "sync keepass: --group must be one name without slash or newline" ;; esac
+      if [ "${#excludes[@]}" -gt 0 ]; then
+        for excluded in "${excludes[@]}"; do
+          [ -n "$excluded" ] || die "sync keepass: --exclude cannot be empty"
+          case "$excluded" in *$'\n'*) die "sync keepass: --exclude cannot contain a newline" ;; esac
+        done
+      fi
+
+      kpxc="${HUSH_KEEPASSXC:-keepassxc-cli}"
+      command -v "$kpxc" >/dev/null 2>&1 || die "sync keepass: '$kpxc' is required (install KeePassXC)"
+      b_exists "$db_secret" || die "sync keepass: no database-password secret named '$db_secret'"
+      if [ "$init" -eq 1 ]; then
+        [ ! -e "$database" ] || die "sync keepass: --init refuses to overwrite existing database '$database'"
+      else
+        [ -f "$database" ] || die "sync keepass: database not found at '$database' (use --init to create it)"
+      fi
+
+      if [ "${#names[@]}" -eq 0 ]; then
+        while IFS= read -r name; do [ -n "$name" ] && names+=("$name"); done < <(b_list)
+      fi
+      [ "${#names[@]}" -gt 0 ] || die "sync keepass: no hush secrets found in namespace '$NS'"
+
+      selected=()
+      for name in "${names[@]}"; do
+        skip=0
+        [ "$name" = "$db_secret" ] && skip=1
+        if [ "${#excludes[@]}" -gt 0 ]; then
+          for excluded in "${excludes[@]}"; do [ "$name" = "$excluded" ] && skip=1; done
+        fi
+        [ "$skip" -eq 1 ] || selected+=("$name")
+      done
+      if [ "${#selected[@]}" -eq 0 ]; then
+        printf 'hush: no KeePass sync candidates remain after exclusions.\n'
+        exit 0
+      fi
+      names=("${selected[@]}")
+
+      for name in "${names[@]}"; do
+        [ -n "$name" ] || die "sync keepass: secret names cannot be empty"
+        case "$name" in *$'\n'*|*/*) die "sync keepass: secret names cannot contain slash or newline ('$name')" ;; esac
+        b_exists "$name" || die "sync keepass: no secret named '$name' (try: hush list)"
+      done
+
+      if [ "$dry_run" -eq 1 ]; then
+        for name in "${names[@]}"; do
+          printf 'hush: would sync %s -> KeePass %s/%s in %s (values not read).\n' "$name" "$group" "$name" "$database"
+        done
+        exit 0
+      fi
+
+      __db=""
+      b_fetch "$db_secret" __db
+      case "$__db" in *$'\n'*) unset __db; die "sync keepass: database password must be one line" ;; esac
+
+      work_db="$database"; init_tmp=""
+      if [ "$init" -eq 1 ]; then
+        db_dir="$(dirname "$database")"
+        mkdir -p "$db_dir" || { unset __db; die "sync keepass: could not create database directory '$db_dir'"; }
+        init_tmp="${database}.hush-init.$$"
+        [ ! -e "$init_tmp" ] || { unset __db; die "sync keepass: temporary database path already exists"; }
+        if ! printf '%s\n%s\n' "$__db" "$__db" | "$kpxc" db-create -q -p "$init_tmp" >/dev/null 2>&1; then
+          unset __db; die "sync keepass: KeePassXC could not create the database"
+        fi
+        work_db="$init_tmp"
+        if ! printf '%s\n' "$__db" | "$kpxc" mkdir -q "$work_db" "$group" >/dev/null 2>&1; then
+          rm -f "$init_tmp"; unset __db; die "sync keepass: KeePassXC could not create group '$group'"
+        fi
+        existing=""
+      else
+        if ! existing="$(printf '%s\n' "$__db" | "$kpxc" ls -q -f "$work_db" "$group" 2>/dev/null)"; then
+          if ! printf '%s\n' "$__db" | "$kpxc" mkdir -q "$work_db" "$group" >/dev/null 2>&1; then
+            unset __db; die "sync keepass: database password was rejected or group '$group' could not be created"
+          fi
+          existing=""
+        fi
+      fi
+
+      actions=()
+      for name in "${names[@]}"; do
+        matches=0
+        while IFS= read -r found; do [ "$found" = "$name" ] && matches=$((matches + 1)); done <<< "$existing"
+        [ "$matches" -le 1 ] || { [ -n "$init_tmp" ] && rm -f "$init_tmp"; unset __db; die "sync keepass: duplicate entry '$group/$name'"; }
+        if [ "$matches" -eq 1 ]; then actions+=(edit); else actions+=(add); fi
+      done
+
+      i=0
+      for name in "${names[@]}"; do
+        __val=""
+        b_fetch "$name" __val
+        case "$__val" in
+          *$'\n'*) [ -n "$init_tmp" ] && rm -f "$init_tmp"; unset __val __db; die "sync keepass: '$name' is multiline; KeePassXC password prompts accept one line" ;;
+        esac
+        entry="$group/$name"
+        if ! printf '%s\n%s\n' "$__db" "$__val" | "$kpxc" "${actions[$i]}" -q -p "$work_db" "$entry" >/dev/null 2>&1; then
+          [ -n "$init_tmp" ] && rm -f "$init_tmp"
+          unset __val __db
+          die "sync keepass: KeePassXC rejected '$entry'; no value was shown"
+        fi
+        unset __val
+        printf 'hush: synced %s -> KeePass %s (value not shown).\n' "$name" "$entry"
+        i=$((i + 1))
+      done
+
+      if [ -n "$init_tmp" ]; then
+        mv "$init_tmp" "$database" || { rm -f "$init_tmp"; unset __db; die "sync keepass: could not place database at '$database'"; }
+        chmod 600 "$database" 2>/dev/null || true
+        printf 'hush: created KeePass database %s. keep its password somewhere recoverable.\n' "$database"
+      fi
+      unset __db
+    fi
     ;;
   file)
     backend_check

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "a secret store for AI agents with one rule: the agent never sees the plaintext. get a secret once into the OS keychain, then inject it into commands forever. no get, cross-platform, MIT.",
   "bin": {
     "hush": "hush",
-    "hush-lastpass-schedule": "helpers/hush-lastpass-schedule.mjs"
+    "hush-lastpass-schedule": "helpers/hush-lastpass-schedule.mjs",
+    "hush-keepass-schedule": "helpers/hush-keepass-schedule.mjs"
   },
   "files": [
     "hush",
     "helpers/hush-lastpass-schedule.mjs",
+    "helpers/hush-keepass-schedule.mjs",
     "win/hush-backend.ps1",
     "SKILL.md",
     "AGENTS.md"

--- a/test/keepass-live.sh
+++ b/test/keepass-live.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Opt-in macOS integration test. Requires KeePassXC and a writable login Keychain.
+set -eu
+set +x
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+hush="$repo/hush"
+kpxc="${HUSH_KEEPASSXC:-keepassxc-cli}"
+command -v "$kpxc" >/dev/null 2>&1 || { printf 'keepassxc-cli is required\n' >&2; exit 1; }
+command -v openssl >/dev/null 2>&1 || { printf 'openssl is required\n' >&2; exit 1; }
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/hush-keepass-live.XXXXXX")"
+database="$work/hush-live.kdbx"
+namespace="hush-keepass-live-$$"
+
+cleanup() {
+  HUSH_NS="$namespace" "$hush" rm keepass-master >/dev/null 2>&1 || true
+  HUSH_NS="$namespace" "$hush" rm live-entry >/dev/null 2>&1 || true
+  rm -f "$database"
+  rmdir "$work" 2>/dev/null || true
+}
+trap cleanup EXIT HUP INT TERM
+
+openssl rand -hex 32 | HUSH_NS="$namespace" "$hush" set keepass-master --pipe >/dev/null
+openssl rand -hex 32 | HUSH_NS="$namespace" "$hush" set live-entry --pipe >/dev/null
+
+HUSH_NS="$namespace" "$hush" sync keepass \
+  --database "$database" --db-secret keepass-master --init live-entry >/dev/null
+
+verify_entry() {
+  HUSH_NS="$namespace" "$hush" run DB=keepass-master EXPECTED=live-entry -- \
+    sh -c '
+      actual="$(printf "%s\n" "$DB" | "$1" show -q -a Password "$2" hush/live-entry 2>/dev/null)"
+      [ "$actual" = "$EXPECTED" ]
+    ' sh "$kpxc" "$database"
+}
+
+verify_entry
+openssl rand -hex 32 | HUSH_NS="$namespace" "$hush" set live-entry --pipe >/dev/null
+HUSH_NS="$namespace" "$hush" sync keepass \
+  --database "$database" --db-secret keepass-master live-entry >/dev/null
+verify_entry
+
+printf 'ok   - real KeePassXC create and update preserve values without printing them\n'

--- a/test/keepass-schedule.mjs
+++ b/test/keepass-schedule.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repo = fileURLToPath(new URL('..', import.meta.url));
+const helper = join(repo, 'helpers', 'hush-keepass-schedule.mjs');
+const root = mkdtempSync(join(tmpdir(), 'hush-keepass-schedule-'));
+const log = join(root, 'commands.log');
+const secretState = join(root, 'hush.db-secret-stored');
+const launchState = join(root, 'launch.loaded');
+const hush = join(root, 'hush');
+const keepassxc = join(root, 'keepassxc-cli');
+const launchctl = join(root, 'launchctl');
+
+function script(path, content) {
+  writeFileSync(path, `#!/usr/bin/env bash\nset -u\n${content}\n`, { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+script(hush, `
+printf 'hush:%s\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  list) [ -f "$HUSH_TEST_SECRET_STATE" ] && printf 'hush-keepass-master-password\n'; exit 0 ;;
+  set) : > "$HUSH_TEST_SECRET_STATE" ;;
+  sync)
+    previous=''
+    for arg in "$@"; do
+      if [ "$previous" = '--database' ] && [ ! -f "$arg" ]; then database=$arg; fi
+      previous=$arg
+    done
+    case " $* " in *' --init '*) : > "$database" ;; esac
+    exit "\${HUSH_TEST_SYNC_RC:-0}" ;;
+  *) exit 42 ;;
+esac`);
+
+script(keepassxc, 'exit 0');
+
+script(launchctl, `
+printf 'launchctl:%s\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  bootstrap) : > "$HUSH_TEST_LAUNCH_STATE" ;;
+  bootout) rm -f "$HUSH_TEST_LAUNCH_STATE" ;;
+  print) [ -f "$HUSH_TEST_LAUNCH_STATE" ] ;;
+  *) exit 43 ;;
+esac`);
+
+const env = {
+  ...process.env,
+  HUSH_KEEPASS_SCHEDULE_HOME: root,
+  HUSH_KEEPASS_SCHEDULE_PLATFORM: 'darwin',
+  HUSH_KEEPASS_SCHEDULE_HUSH: hush,
+  HUSH_KEEPASS_SCHEDULE_KEEPASSXC: keepassxc,
+  HUSH_KEEPASS_SCHEDULE_LAUNCHCTL: launchctl,
+  HUSH_TEST_LOG: log,
+  HUSH_TEST_SECRET_STATE: secretState,
+  HUSH_TEST_LAUNCH_STATE: launchState,
+};
+
+function invoke(args, extraEnv = {}) {
+  return spawnSync(process.execPath, [helper, ...args], {
+    env: { ...env, ...extraEnv },
+    encoding: 'utf8',
+  });
+}
+
+function ok(label) { process.stdout.write(`ok   - ${label}\n`); }
+
+try {
+  const database = join(root, 'Library', 'Mobile Documents', 'com~apple~CloudDocs', 'hush', 'hush.kdbx');
+  let result = invoke([
+    'install', '--every', '6h', '--group', 'hush', '--exclude', 'local-only', 'selected-a',
+  ]);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(existsSync(database), true);
+  ok('cold install creates and populates the iCloud-path database');
+
+  const configPath = join(root, 'Library', 'Application Support', 'hush', 'keepass-schedule.json');
+  const plistPath = join(root, 'Library', 'LaunchAgents', 'com.royashbrook.hush.keepass-sync.plist');
+  const config = JSON.parse(readFileSync(configPath, 'utf8'));
+  assert.equal(config.database, database);
+  assert.equal(config.dbSecret, 'hush-keepass-master-password');
+  assert.deepEqual(config.excludes, ['local-only']);
+  assert.deepEqual(config.names, ['selected-a']);
+  assert.equal(config.seconds, 21600);
+  assert.equal(statSync(configPath).mode & 0o777, 0o600);
+  assert.ok(!readFileSync(configPath, 'utf8').includes('database-password-value'));
+  ok('config is mode 0600 metadata only');
+
+  const plist = readFileSync(plistPath, 'utf8');
+  assert.match(plist, /<integer>21600<\/integer>/);
+  assert.match(plist, /<string>run<\/string>/);
+  assert.ok(!plist.includes('hush-keepass-master-password'));
+  assert.ok(!plist.includes(database));
+  ok('LaunchAgent contains only runner and config paths');
+
+  let commands = readFileSync(log, 'utf8');
+  assert.match(commands, /hush:set hush-keepass-master-password/);
+  assert.match(commands, /hush:sync keepass --database .*hush\.kdbx --db-secret hush-keepass-master-password --group hush --exclude local-only --init selected-a/);
+  assert.match(commands, /launchctl:bootstrap gui\/\d+ /);
+  assert.ok(!commands.includes('database-password-value'));
+  ok('install stores the password, initializes once, then loads launchd');
+
+  writeFileSync(log, '');
+  result = invoke(['run']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  commands = readFileSync(log, 'utf8');
+  assert.match(commands, /hush:sync keepass --database .*hush\.kdbx --db-secret hush-keepass-master-password --group hush --exclude local-only selected-a/);
+  assert.match(result.stdout, /sync ok/);
+  ok('scheduled run upserts without exposing secret material');
+
+  result = invoke(['status']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /loaded, every 6h/);
+  ok('status reports loaded schedule');
+
+  result = invoke(['remove']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(existsSync(plistPath), false);
+  assert.equal(existsSync(configPath), true);
+  assert.equal(existsSync(database), true);
+  ok('remove unloads launchd and retains config plus database');
+
+  writeFileSync(log, '');
+  result = invoke(['install', '--every', '1d']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  commands = readFileSync(log, 'utf8');
+  assert.match(commands, /hush:sync keepass .* --dry-run/);
+  assert.ok(!commands.includes('hush:set'));
+  assert.ok(!commands.includes(' --init'));
+  ok('existing database is validated without recreation or another password prompt');
+
+  process.stdout.write('# KeePass schedule tests done. failures: 0\n');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/test/keepass-sync.sh
+++ b/test/keepass-sync.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Deterministic KeePass sync tests. OS storage and keepassxc-cli are fakes, so no real keychain or
+# KDBX is touched. Test values may enter fake stdin, but never fake argv, output, or logs.
+set -uo pipefail
+
+HUSH="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)/hush"
+STUB="$(mktemp -d 2>/dev/null || echo "${TMPDIR:-/tmp}/hush-keepass-test-$$")"
+STORE="$STUB/store"
+export HUSH_TEST_STORE="$STORE"
+export HUSH_KEEPASS_LOG="$STUB/keepass.log"
+export HUSH_KEEPASS_ENTRIES="$STUB/entries"
+export HUSH_KEEPASS_GROUP="$STUB/group"
+export HUSH_NS="hush-keepass-test-$$"
+export HUSH_KEEPASSXC="$STUB/keepassxc-cli"
+export HUSH_KEEPASS_DB_EXPECT="KP-DB-$$-never-log-this"
+SENTINEL="KP-S3NT-$$-never-log-this"
+DATABASE="$STUB/hush.kdbx"
+fails=0
+
+mkdir -p "$STORE"
+: > "$HUSH_KEEPASS_ENTRIES"
+cleanup() { rm -rf "$STUB" 2>/dev/null; }
+trap cleanup EXIT
+ok()  { printf 'ok   - %s\n' "$1"; }
+bad() { printf 'FAIL - %s\n' "$1"; fails=$((fails + 1)); }
+run_hush() { env PATH="$STUB:$PATH" "$HUSH" "$@"; }
+
+printf '%s\n' '#!/bin/sh' \
+  'if [ "${1:-}" = -s ]; then printf "Darwin\n"; else /usr/bin/uname "$@"; fi' > "$STUB/uname"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -u' \
+  'verb="${1:-}"; shift || true' \
+  'service=""; value=""; bare_w=0' \
+  'while [ $# -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -s) service="$2"; shift 2 ;;' \
+  '    -w) if [ $# -gt 1 ]; then value="$2"; shift 2; else bare_w=1; shift; fi ;;' \
+  '    *) shift ;;' \
+  '  esac' \
+  'done' \
+  'case "$verb" in' \
+  '  add-generic-password)' \
+  '    if [ "$bare_w" -eq 1 ]; then IFS= read -r value || true; IFS= read -r confirm || true; [ "$value" = "$confirm" ] || exit 46; fi' \
+  '    printf "%s" "$value" > "$HUSH_TEST_STORE/$service" ;;' \
+  '  find-generic-password)' \
+  '    [ -f "$HUSH_TEST_STORE/$service" ] || exit 44' \
+  '    if [ "$bare_w" -eq 1 ]; then cat "$HUSH_TEST_STORE/$service"; fi ;;' \
+  '  delete-generic-password) rm -f "$HUSH_TEST_STORE/$service" ;;' \
+  '  dump-keychain)' \
+  '    for item in "$HUSH_TEST_STORE"/*; do' \
+  '      [ -f "$item" ] || continue' \
+  "      printf '    \"svce\"<blob>=\"%s\"\\n' \"\${item##*/}\"" \
+  '    done ;;' \
+  '  *) exit 45 ;;' \
+  'esac' > "$STUB/security"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -u' \
+  'verb="${1:-}"; shift || true' \
+  'printf "kpxc:%s %s\n" "$verb" "$*" >> "$HUSH_KEEPASS_LOG"' \
+  'last=""; for arg in "$@"; do last="$arg"; done' \
+  'case "$verb" in' \
+  '  db-create)' \
+  '    IFS= read -r db1 || true; IFS= read -r db2 || true' \
+  '    [ "$db1" = "$HUSH_KEEPASS_DB_EXPECT" ] && [ "$db2" = "$db1" ] || exit 51' \
+  '    : > "$last" ;;' \
+  '  mkdir)' \
+  '    IFS= read -r db || true; [ "$db" = "$HUSH_KEEPASS_DB_EXPECT" ] || exit 52' \
+  '    : > "$HUSH_KEEPASS_GROUP" ;;' \
+  '  ls)' \
+  '    IFS= read -r db || true; [ "$db" = "$HUSH_KEEPASS_DB_EXPECT" ] || exit 53' \
+  '    [ -f "$HUSH_KEEPASS_GROUP" ] || exit 54' \
+  '    cat "$HUSH_KEEPASS_ENTRIES" ;;' \
+  '  add|edit)' \
+  '    IFS= read -r db || true; IFS= read -r entry_value || true' \
+  '    [ "$db" = "$HUSH_KEEPASS_DB_EXPECT" ] || exit 55' \
+  '    [ -n "$entry_value" ] || exit 56' \
+  '    if [ "${HUSH_KEEPASS_EXPECT+x}" = x ] && [ "$entry_value" != "$HUSH_KEEPASS_EXPECT" ]; then exit 57; fi' \
+  '    title="${last##*/}"; count="$(grep -cFx "$title" "$HUSH_KEEPASS_ENTRIES" 2>/dev/null || true)"' \
+  '    if [ "$verb" = add ]; then [ "$count" -eq 0 ] || exit 58; printf "%s\n" "$title" >> "$HUSH_KEEPASS_ENTRIES"; else [ "$count" -eq 1 ] || exit 59; fi' \
+  '    printf "value-ok\n" >> "$HUSH_KEEPASS_LOG" ;;' \
+  '  *) exit 60 ;;' \
+  'esac' > "$STUB/keepassxc-cli"
+chmod +x "$STUB/uname" "$STUB/security" "$STUB/keepassxc-cli"
+
+printf '%s' "$HUSH_KEEPASS_DB_EXPECT" | run_hush set kp-db --pipe >/dev/null 2>&1
+printf '%s' "$SENTINEL" | run_hush set sync-a --pipe >/dev/null 2>&1
+run_hush mint sync-b --bytes 4 >/dev/null 2>&1
+
+: > "$HUSH_KEEPASS_LOG"
+out="$(run_hush sync keepass --init --dry-run --database "$DATABASE" --db-secret kp-db sync-a 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "init dry-run succeeds" || bad "init dry-run failed (got: $out)"
+[ ! -e "$DATABASE" ] && ok "dry-run creates no database" || bad "dry-run created database"
+grep -q '^kpxc:' "$HUSH_KEEPASS_LOG" && bad "dry-run invoked KeePassXC" || ok "dry-run reads no values or database"
+
+: > "$HUSH_KEEPASS_LOG"
+out="$(HUSH_KEEPASS_EXPECT="$SENTINEL" run_hush sync keepass --init --database "$DATABASE" --db-secret kp-db sync-a 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && [ -f "$DATABASE" ] && ok "database initializes and selected secret syncs" || bad "init sync failed (got: $out)"
+grep -q '^kpxc:db-create -q -p ' "$HUSH_KEEPASS_LOG" && grep -q '^kpxc:mkdir -q ' "$HUSH_KEEPASS_LOG" && grep -q '^kpxc:add -q -p ' "$HUSH_KEEPASS_LOG" && ok "init uses create, group, then add" || bad "init command sequence wrong"
+grep -qF "$SENTINEL" "$HUSH_KEEPASS_LOG" && bad "entry value reached KeePass argv/log" || ok "entry value stays out of KeePass argv/log"
+grep -qF "$HUSH_KEEPASS_DB_EXPECT" "$HUSH_KEEPASS_LOG" && bad "database password reached KeePass argv/log" || ok "database password stays out of KeePass argv/log"
+printf '%s' "$out" | grep -qF "$SENTINEL" && bad "entry value leaked in output" || ok "success output does not leak"
+
+: > "$HUSH_KEEPASS_LOG"
+out="$(run_hush sync keepass --database "$DATABASE" --db-secret kp-db 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "bulk upsert succeeds" || bad "bulk upsert failed (got: $out)"
+grep -q '^kpxc:edit .*hush/sync-a$' "$HUSH_KEEPASS_LOG" && grep -q '^kpxc:add .*hush/sync-b$' "$HUSH_KEEPASS_LOG" && ok "bulk chooses edit and add" || bad "bulk upsert actions wrong"
+grep -q 'hush/kp-db$' "$HUSH_KEEPASS_LOG" && bad "database secret was synced" || ok "database secret is always excluded"
+
+: > "$HUSH_KEEPASS_LOG"
+out="$(run_hush sync keepass --database "$DATABASE" --db-secret kp-db missing-name 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "missing selection fails" || bad "missing selection accepted"
+grep -q '^kpxc:\(add\|edit\)' "$HUSH_KEEPASS_LOG" && bad "write happened before selection validation" || ok "selection validates before write"
+
+printf 'line one\nline two' | run_hush set sync-multiline --pipe >/dev/null 2>&1
+: > "$HUSH_KEEPASS_LOG"
+out="$(run_hush sync keepass --database "$DATABASE" --db-secret kp-db sync-multiline 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "multiline value is refused" || bad "multiline value accepted"
+grep -q '^kpxc:\(add\|edit\)' "$HUSH_KEEPASS_LOG" && bad "multiline value reached KeePass" || ok "multiline refusal precedes write"
+
+out="$(run_hush sync keepass --database "$DATABASE" --db-secret kp-db bad/name 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "slash-bearing name is refused" || bad "slash-bearing name accepted"
+
+printf 'sync-a\n' >> "$HUSH_KEEPASS_ENTRIES"
+: > "$HUSH_KEEPASS_LOG"
+out="$(run_hush sync keepass --database "$DATABASE" --db-secret kp-db sync-a 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "duplicate entry fails closed" || bad "duplicate entry accepted"
+grep -q '^kpxc:\(add\|edit\)' "$HUSH_KEEPASS_LOG" && bad "duplicate entry was written" || ok "duplicate detection precedes write"
+
+printf '# KeePass sync tests done. failures: %s\n' "$fails"
+[ "$fails" -eq 0 ]

--- a/test/test.sh
+++ b/test/test.sh
@@ -133,5 +133,17 @@ else
   bad "isolated LastPass schedule suite"
 fi
 
+if bash "$(dirname "${BASH_SOURCE[0]:-$0}")/keepass-sync.sh"; then
+  ok "isolated KeePass sync suite"
+else
+  bad "isolated KeePass sync suite"
+fi
+
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/keepass-schedule.mjs"; then
+  ok "isolated KeePass schedule suite"
+else
+  bad "isolated KeePass schedule suite"
+fi
+
 echo "# done. failures: $fails"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
Adds one-way hush to KeePassXC KDBX upserts plus an npm-shipped macOS launchd helper defaulting to iCloud Drive. Includes init-without-overwrite, selected and bulk sync, exclusions, duplicate fail-closed behavior, stdin-only credential handling, recovery guidance, and cold-install scheduling.\n\nVerified with the full macOS suite, deterministic core and scheduler suites, npm pack inspection, and a disposable real KeePassXC database create/update test with random values never printed.\n\nCloses #11