### PR TITLE
feat: add Bitwarden sync and unattended scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ hush run TOKEN=my-vendor-token -- some-cmd    # inject into a command, never pri
 hush sync lastpass --dry-run                  # preview a one-way LastPass sync
 hush sync lastpass                            # upsert every name under LastPass group "hush"
 hush sync keepass --database vault.kdbx --db-secret keepass-password --dry-run
+hush sync bitwarden --dry-run                 # requires an unlocked BW_SESSION
 hush list                                     # names only, never values
 ```
 
@@ -188,6 +189,52 @@ the database and mode-0600 metadata config.
 Keep one durable copy of the database password outside this KDBX. After a machine loss, the iCloud
 file cannot recover the hush secret that unlocks it. Treat one machine as the writer while iCloud is
 syncing to avoid conflicted KDBX copies.
+
+## sync to Bitwarden
+
+The official [Bitwarden CLI](https://bitwarden.com/help/cli/) supports create and edit operations,
+API-key login, and session-based vault access. Install it, then keep the three required credentials
+in hush:
+
+~~~sh
+brew install bitwarden-cli
+hush set bitwarden-client-id
+hush set bitwarden-client-secret
+hush set bitwarden-master-password
+~~~
+
+Bitwarden's personal API key authenticates the CLI, but [does not replace the master
+password](https://bitwarden.com/help/personal-api-key/). Vault reads and writes still require an
+unlock session. The npm-shipped scheduler handles that lifecycle without repeated interaction:
+
+~~~sh
+hush-bitwarden-schedule install --every 6h
+hush-bitwarden-schedule status
+~~~
+
+Install verifies all three hush names, performs bw login --apikey when needed, unlocks with
+--passwordenv, runs a value-free dry-run, then installs launchd. Each scheduled run obtains a
+short-lived session, syncs, and locks the CLI. API credentials, the master password, and the session
+are absent from argv, logs, the plist, and the mode-0600 metadata config.
+
+The underlying command can also be used inside any already-unlocked Bitwarden CLI session:
+
+~~~sh
+hush sync bitwarden --dry-run
+hush sync bitwarden                         # all non-auth secrets -> folder hush
+hush sync bitwarden --folder backups api-key deploy-key
+hush sync bitwarden --exclude local-only
+~~~
+
+Missing login items are created and unique items are updated. Exact duplicate names in the target
+folder fail closed. Existing item JSON flows directly from bw into the JSON transformer, and encoded
+create/edit bodies flow directly into bw over stdin. Passwords never enter argv, stdout, logs, or
+temp files. The three default Bitwarden auth secrets are always excluded. Bitwarden automatically
+pushes successful create and edit changes to the server.
+
+The core sync is Bash plus Node and follows the platforms supported by hush and bw. The included
+scheduler currently installs a macOS LaunchAgent. hush-bitwarden-schedule remove unloads it while
+retaining the non-secret config and hush credentials.
 
 ## not a vault
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,6 +115,7 @@ hush pipe <name> -- <cmd>                # stream the value to <cmd>'s stdin
 hush sync lastpass [name ...]            # upsert selected names, or all names when omitted
 hush sync lastpass --exclude <name>       # keep a local-only name out of bulk sync; repeatable
 hush sync keepass --database <file.kdbx> --db-secret <name> [name ...]
+hush sync bitwarden [name ...]           # requires an unlocked BW_SESSION
 hush list                                # NAMES only, never values
 hush rename <old> <new>                  # move to a new name (value moved INTERNALLY, never re-asked)
 hush rm   <name>                         # delete
@@ -188,6 +189,36 @@ Install creates and populates an absent database. If the database-password secre
 it invokes hush's hidden prompt. Keep a separate durable copy of that password, because a recovered
 KDBX cannot recover the local hush secret needed to open it. Avoid simultaneous writers while the
 file is syncing through iCloud.
+
+For a hosted Bitwarden copy, use the official bw CLI. API-key login needs the client ID and client
+secret, but Bitwarden still requires the master password to unlock vault data:
+
+~~~
+hush set bitwarden-client-id
+hush set bitwarden-client-secret
+hush set bitwarden-master-password
+hush-bitwarden-schedule install --every 6h
+hush-bitwarden-schedule status
+~~~
+
+The Node scheduler performs API-key login only when unauthenticated, unlocks with
+--passwordenv BW_PASSWORD, passes a short-lived BW_SESSION only to the sync child, then locks the
+CLI. Credentials and session values never reach argv, logs, plist, config, or stdout. Missing hush
+credentials are collected through the hidden prompt during install. The default three auth-secret
+names are forcibly excluded from backup.
+
+Inside an already unlocked bw session, the core target is:
+
+~~~
+hush sync bitwarden --dry-run
+hush sync bitwarden
+hush sync bitwarden --folder backups foo
+hush sync bitwarden --exclude local-only
+~~~
+
+It creates missing login items, updates unique items, and fails closed on duplicate exact names in
+the target folder. Existing JSON and encoded create/edit bodies move through pipes, never temp files
+or argv. The core uses Bash plus Node. Scheduling currently targets macOS launchd.
 
 > **Escape hatch, `hush file <name> <path>`.** A few tools can *only* read a credential from a file
 > path (a service-account JSON, a cert, a kubeconfig). For those, and only those, `hush file` writes a
@@ -291,9 +322,9 @@ a sticky note.
 Treat it as an **on-ramp.** Two wins land immediately, even with no `hush exec` in sight: you can
 generate secrets securely from day one, and on an old project with values scattered across `.env`s,
 dashboards, and your head, a few pastes get them (a) centralized and (b) agent-usable from then on.
-For a durable, shareable home, **sync them onward**. LastPass and KeePassXC have built-in one-way
-sync targets, and *extending hush* covers other CLIs and store backends. hush gets you consistent;
-the sync makes it permanent.
+For a durable, shareable home, **sync them onward**. LastPass, KeePassXC, and Bitwarden have built-in
+one-way sync targets, and *extending hush* covers other CLIs and store backends. hush gets you
+consistent; the sync makes it permanent.
 
 ## extending hush to the tools you already use
 
@@ -301,7 +332,8 @@ The friction this kills: *"go create this key, then paste it into GitHub / Wrang
 tell me when it's there."* If the agent already has the CLI for that tool, it shouldn't hand that
 back, it should just do it. Two directions:
 
-1. **Push a hush-held secret INTO another tool.** LastPass and KeePassXC are built in as `hush sync` targets.
+1. **Push a hush-held secret INTO another tool.** LastPass, KeePassXC, and Bitwarden are built in as
+   `hush sync` targets.
    Anything else with a CLI that takes the value on stdin is already a consumer via `pipe`:
    ```
    hush pipe deploy-token -- gh secret set DEPLOY_TOKEN          # into GitHub Actions

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -43,6 +43,27 @@ Database and entry passwords travel to `keepassxc-cli` only on stdin. The databa
 is always excluded from sync. `remove` unloads launchd while retaining the KDBX and config. Keep a
 separate durable copy of the database password and avoid simultaneous iCloud writers.
 
+## hush-bitwarden-schedule, unattended hosted-vault sync (macOS)
+
+The npm package installs this Node helper beside hush:
+
+~~~sh
+brew install bitwarden-cli
+hush-bitwarden-schedule install --every 6h
+hush-bitwarden-schedule status
+hush-bitwarden-schedule remove
+~~~
+
+It expects bitwarden-client-id, bitwarden-client-secret, and bitwarden-master-password in hush,
+prompting through hush for any missing value. The API key authenticates bw; the master password is
+still required to unlock vault data. Each run obtains a short-lived session, invokes
+hush sync bitwarden, then locks the CLI.
+
+Credentials and session values stay out of argv, logs, plist, and the mode-0600 metadata config. The
+three auth-secret names are always excluded from sync. Use --folder, repeatable --exclude,
+positional secret names, and --every to configure selection. remove unloads launchd but retains the
+config and hush credentials.
+
 ## hush-backup, encrypted off-machine backup of the store (macOS + iCloud)
 
 A hush store lives only in the local OS keychain, so a wipe means re-provisioning every secret.

--- a/helpers/hush-bitwarden-json.mjs
+++ b/helpers/hush-bitwarden-json.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+function die(message, code = 1) {
+  process.stderr.write(`hush-bitwarden-json: ${message}\n`);
+  process.exit(code);
+}
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let value = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { value += chunk; });
+    process.stdin.on('end', () => resolve(value));
+  });
+}
+
+function json(value, label) {
+  try { return JSON.parse(value); }
+  catch { die(`invalid JSON from Bitwarden (${label})`); }
+}
+
+function encoded(value) {
+  process.stdout.write(Buffer.from(JSON.stringify(value), 'utf8').toString('base64'));
+}
+
+const [command, ...args] = process.argv.slice(2);
+const input = await readStdin();
+
+if (command === 'status') {
+  const value = json(input, 'status');
+  process.exit(value.status === 'unlocked' ? 0 : 2);
+}
+
+if (command === 'folder') {
+  const [name] = args;
+  const values = json(input, 'folder list');
+  if (!Array.isArray(values)) die('folder list was not an array');
+  const matches = values.filter((value) => value && value.name === name);
+  if (matches.length > 1) die(`duplicate folder name '${name}'`, 3);
+  if (matches.length === 1) process.stdout.write(String(matches[0].id));
+  process.exit(0);
+}
+
+if (command === 'item') {
+  const [name, folderId] = args;
+  const values = json(input, 'item list');
+  if (!Array.isArray(values)) die('item list was not an array');
+  const matches = values.filter((value) => (
+    value && value.name === name && String(value.folderId || '') === folderId
+  ));
+  if (matches.length > 1) die(`duplicate item name '${name}'`, 3);
+  if (matches.length === 1) process.stdout.write(String(matches[0].id));
+  process.exit(0);
+}
+
+if (command === 'id') {
+  const value = json(input, 'created object');
+  if (!value || !value.id) die('Bitwarden response had no id');
+  process.stdout.write(String(value.id));
+  process.exit(0);
+}
+
+if (command === 'folder-create') {
+  const [name] = args;
+  const value = json(input, 'folder template');
+  value.name = name;
+  encoded(value);
+  process.exit(0);
+}
+
+if (command === 'item-create' || command === 'item-update') {
+  const [name, folderId] = args;
+  if (!Object.hasOwn(process.env, 'HUSH_BITWARDEN_VALUE')) die('missing protected item value');
+  const value = json(input, command === 'item-create' ? 'item template' : 'existing item');
+  value.type = 1;
+  value.name = name;
+  value.folderId = folderId;
+  if (!value.login || typeof value.login !== 'object') value.login = {};
+  value.login.password = process.env.HUSH_BITWARDEN_VALUE;
+  encoded(value);
+  process.exit(0);
+}
+
+die('unknown command');

--- a/helpers/hush-bitwarden-schedule.mjs
+++ b/helpers/hush-bitwarden-schedule.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, delimiter, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const LABEL = 'com.royashbrook.hush.bitwarden-sync';
+const SCRIPT = fileURLToPath(import.meta.url);
+const JSON_HELPER = fileURLToPath(new URL('hush-bitwarden-json.mjs', import.meta.url));
+
+function die(message) {
+  process.stderr.write(`hush-bitwarden-schedule: ${message}\n`);
+  process.exit(1);
+}
+
+function usage(code = 0) {
+  const out = code ? process.stderr : process.stdout;
+  out.write(`hush-bitwarden-schedule, recurring hush -> Bitwarden sync
+
+  hush-bitwarden-schedule install [--every 6h] [options] [name ...]
+  hush-bitwarden-schedule run
+  hush-bitwarden-schedule status
+  hush-bitwarden-schedule remove
+
+options:
+  --client-id-secret <name>      default: bitwarden-client-id
+  --client-secret-secret <name>  default: bitwarden-client-secret
+  --master-secret <name>         default: bitwarden-master-password
+  --folder <name>                Bitwarden folder (default: hush)
+  --exclude <name>               omit from bulk sync; repeatable
+  --every <Nm|Nh|Nd>             interval, minimum 5m (default: 6h)
+
+the API key authenticates the CLI, but Bitwarden still requires the master password to unlock vault
+data. install stores missing values through hush's hidden prompt, then validates login and unlock.
+`);
+  process.exit(code);
+}
+
+function roots() {
+  const home = process.env.HUSH_BITWARDEN_SCHEDULE_HOME || homedir();
+  return {
+    home,
+    config: join(home, 'Library', 'Application Support', 'hush', 'bitwarden-schedule.json'),
+    plist: join(home, 'Library', 'LaunchAgents', `${LABEL}.plist`),
+    log: join(home, 'Library', 'Logs', 'hush-bitwarden-sync.log'),
+  };
+}
+
+function findExecutable(name, override) {
+  if (override) {
+    if (existsSync(override)) return override;
+    die(`configured ${name} executable does not exist: ${override}`);
+  }
+  for (const dir of (process.env.PATH || '').split(delimiter)) {
+    const candidate = join(dir, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  die(`${name} is not on PATH`);
+}
+
+function run(program, args, options = {}) {
+  return spawnSync(program, args, {
+    encoding: 'utf8',
+    env: options.env || process.env,
+    stdio: options.stdio || 'pipe',
+  });
+}
+
+function seconds(value) {
+  const match = /^(\d+)(m|h|d)$/.exec(value);
+  if (!match) die(`bad interval '${value}' (use Nm, Nh, or Nd)`);
+  const unit = { m: 60, h: 3600, d: 86400 }[match[2]];
+  const result = Number(match[1]) * unit;
+  if (result < 300) die('interval must be at least 5m');
+  return result;
+}
+
+function xml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function writeAtomic(path, value, mode = 0o600) {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temp = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`);
+  writeFileSync(temp, value, { mode });
+  renameSync(temp, path);
+}
+
+function parseInstall(args) {
+  const result = {
+    clientIdSecret: 'bitwarden-client-id',
+    clientSecretSecret: 'bitwarden-client-secret',
+    masterSecret: 'bitwarden-master-password',
+    folder: 'hush', excludes: [], every: '6h', names: [],
+  };
+  while (args.length) {
+    const arg = args.shift();
+    if (arg === '--client-id-secret') result.clientIdSecret = args.shift() || die('--client-id-secret needs a name');
+    else if (arg === '--client-secret-secret') result.clientSecretSecret = args.shift() || die('--client-secret-secret needs a name');
+    else if (arg === '--master-secret') result.masterSecret = args.shift() || die('--master-secret needs a name');
+    else if (arg === '--folder') result.folder = args.shift() || die('--folder needs a name');
+    else if (arg === '--exclude') result.excludes.push(args.shift() || die('--exclude needs a name'));
+    else if (arg === '--every') result.every = args.shift() || die('--every needs an interval');
+    else if (arg === '--') { result.names.push(...args); break; }
+    else if (arg.startsWith('-')) die(`unknown option '${arg}'`);
+    else result.names.push(arg);
+  }
+  if (!result.folder || /[\r\n]/.test(result.folder)) die('--folder must be non-empty and one line');
+  for (const name of [result.clientIdSecret, result.clientSecretSecret, result.masterSecret]) {
+    if (!name || /[\r\n]/.test(name)) die('auth secret names must be non-empty and one line');
+  }
+  result.seconds = seconds(result.every);
+  return result;
+}
+
+function syncArgs(config, dryRun = false) {
+  const args = ['sync', 'bitwarden', '--folder', config.folder];
+  const excluded = new Set([
+    ...config.excludes,
+    config.clientIdSecret, config.clientSecretSecret, config.masterSecret,
+  ]);
+  for (const name of excluded) args.push('--exclude', name);
+  if (dryRun) args.push('--dry-run');
+  args.push(...config.names);
+  return args;
+}
+
+function readConfig(path) {
+  if (!existsSync(path)) die(`no schedule config at ${path} (run install)`);
+  try { return JSON.parse(readFileSync(path, 'utf8')); }
+  catch { die(`could not read schedule config at ${path}`); }
+}
+
+function encodedConfig(config, dryRun) {
+  return Buffer.from(JSON.stringify({ ...config, dryRun }), 'utf8').toString('base64');
+}
+
+function invokeAuthenticated(config, dryRun, stdio = 'inherit') {
+  return run(config.hush, [
+    'run',
+    `BW_CLIENTID=${config.clientIdSecret}`,
+    `BW_CLIENTSECRET=${config.clientSecretSecret}`,
+    `BW_PASSWORD=${config.masterSecret}`,
+    '--', process.execPath, SCRIPT, 'authenticated-run', '--config64', encodedConfig(config, dryRun),
+  ], { stdio });
+}
+
+function parseStatus(result) {
+  if (result.status !== 0) return { status: 'error' };
+  try { return JSON.parse(result.stdout); }
+  catch { return { status: 'error' }; }
+}
+
+function authenticatedRun(config) {
+  const authEnv = { ...process.env };
+  let status = parseStatus(run(config.bw, ['status'], { env: authEnv }));
+  const expectedUser = authEnv.BW_CLIENTID?.startsWith('user.') ? authEnv.BW_CLIENTID.slice(5) : '';
+  if (expectedUser && status.userId && expectedUser.toLowerCase() !== status.userId.toLowerCase()) {
+    die('authenticated Bitwarden account does not match the configured personal API key');
+  }
+  if (status.status === 'unauthenticated') {
+    const login = run(config.bw, ['login', '--apikey'], { env: authEnv });
+    if (login.status !== 0) die('Bitwarden API-key login failed');
+    status = parseStatus(run(config.bw, ['status'], { env: authEnv }));
+  }
+  if (status.status !== 'locked' && status.status !== 'unlocked') {
+    die(`unexpected Bitwarden status '${status.status}'`);
+  }
+
+  let session = '';
+  if (status.status === 'unlocked' && authEnv.BW_SESSION) session = authEnv.BW_SESSION;
+  else {
+    const unlocked = run(config.bw, ['unlock', '--passwordenv', 'BW_PASSWORD', '--raw'], { env: authEnv });
+    if (unlocked.status !== 0) die('Bitwarden unlock failed');
+    session = unlocked.stdout.trim();
+  }
+  if (!session) die('Bitwarden returned an empty session');
+
+  const syncEnv = {
+    ...process.env,
+    BW_SESSION: session,
+    HUSH_BITWARDEN: config.bw,
+    HUSH_BITWARDEN_JSON: config.jsonHelper,
+    HUSH_NODE: process.execPath,
+  };
+  delete syncEnv.BW_CLIENTID;
+  delete syncEnv.BW_CLIENTSECRET;
+  delete syncEnv.BW_PASSWORD;
+  delete process.env.BW_CLIENTID;
+  delete process.env.BW_CLIENTSECRET;
+  delete process.env.BW_PASSWORD;
+
+  const synced = run(config.hush, syncArgs(config, config.dryRun), { env: syncEnv, stdio: 'inherit' });
+  run(config.bw, ['lock'], { env: syncEnv });
+  session = '';
+  if (synced.status !== 0) die(`sync failed with exit ${synced.status}`);
+  if (!config.dryRun) process.stdout.write(`hush-bitwarden-schedule: ${new Date().toISOString()} sync ok\n`);
+}
+
+function install(args) {
+  const platform = process.env.HUSH_BITWARDEN_SCHEDULE_PLATFORM || process.platform;
+  if (platform !== 'darwin') die('schedule install currently supports macOS launchd only');
+  const options = parseInstall(args);
+  const paths = roots();
+  const hush = findExecutable('hush', process.env.HUSH_BITWARDEN_SCHEDULE_HUSH);
+  const bw = findExecutable('bw', process.env.HUSH_BITWARDEN_SCHEDULE_BW);
+  const launchctl = findExecutable('launchctl', process.env.HUSH_BITWARDEN_SCHEDULE_LAUNCHCTL);
+  const config = {
+    version: 1, hush, bw, jsonHelper: JSON_HELPER,
+    clientIdSecret: options.clientIdSecret,
+    clientSecretSecret: options.clientSecretSecret,
+    masterSecret: options.masterSecret,
+    folder: options.folder, excludes: options.excludes, names: options.names,
+    every: options.every, seconds: options.seconds,
+  };
+
+  const listed = run(hush, ['list']);
+  if (listed.status !== 0) die('could not list hush secret names');
+  const present = new Set(listed.stdout.split(/\r?\n/).filter(Boolean));
+  for (const name of [config.clientIdSecret, config.clientSecretSecret, config.masterSecret]) {
+    if (present.has(name)) continue;
+    process.stdout.write(`hush-bitwarden-schedule: store required credential as hush secret '${name}'.\n`);
+    const stored = run(hush, ['set', name], { stdio: 'inherit' });
+    if (stored.status !== 0) die(`credential '${name}' was not stored; nothing installed`);
+  }
+
+  const preview = invokeAuthenticated(config, true);
+  if (preview.status !== 0) die('authenticated sync dry-run failed; nothing installed');
+  writeAtomic(paths.config, `${JSON.stringify(config, null, 2)}\n`);
+  mkdirSync(dirname(paths.log), { recursive: true });
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xml(process.execPath)}</string>
+    <string>${xml(SCRIPT)}</string>
+    <string>run</string>
+    <string>--config</string>
+    <string>${xml(paths.config)}</string>
+  </array>
+  <key>StartInterval</key><integer>${config.seconds}</integer>
+  <key>RunAtLoad</key><true/>
+  <key>StandardOutPath</key><string>${xml(paths.log)}</string>
+  <key>StandardErrorPath</key><string>${xml(paths.log)}</string>
+</dict>
+</plist>
+`;
+  writeAtomic(paths.plist, plist);
+
+  const domain = `gui/${process.getuid()}`;
+  run(launchctl, ['bootout', domain, paths.plist]);
+  const loaded = run(launchctl, ['bootstrap', domain, paths.plist]);
+  if (loaded.status !== 0) die(`launchctl bootstrap failed; config and plist remain at ${paths.plist}`);
+  process.stdout.write(`hush-bitwarden-schedule: installed every ${config.every}. log: ${paths.log}\n`);
+}
+
+function scheduledRun(configPath) {
+  const config = readConfig(configPath);
+  const result = invokeAuthenticated(config, false);
+  if (result.status !== 0) die(`authenticated runner failed with exit ${result.status}`);
+}
+
+function status() {
+  const paths = roots();
+  const config = readConfig(paths.config);
+  const launchctl = findExecutable('launchctl', process.env.HUSH_BITWARDEN_SCHEDULE_LAUNCHCTL);
+  const result = run(launchctl, ['print', `gui/${process.getuid()}/${LABEL}`]);
+  process.stdout.write(`hush-bitwarden-schedule: ${result.status === 0 ? 'loaded' : 'not loaded'}, every ${config.every}, folder ${config.folder}\n`);
+  process.exit(result.status === 0 ? 0 : 1);
+}
+
+function remove() {
+  const paths = roots();
+  const launchctl = findExecutable('launchctl', process.env.HUSH_BITWARDEN_SCHEDULE_LAUNCHCTL);
+  run(launchctl, ['bootout', `gui/${process.getuid()}`, paths.plist]);
+  rmSync(paths.plist, { force: true });
+  process.stdout.write('hush-bitwarden-schedule: removed LaunchAgent. config and hush credentials retained.\n');
+}
+
+const [command = 'help', ...args] = process.argv.slice(2);
+if (command === 'install') install(args);
+else if (command === 'run') {
+  let config = roots().config;
+  if (args[0] === '--config' && args[1]) config = args[1];
+  scheduledRun(config);
+} else if (command === 'authenticated-run') {
+  if (args[0] !== '--config64' || !args[1]) die('missing internal config');
+  let config;
+  try { config = JSON.parse(Buffer.from(args[1], 'base64').toString('utf8')); }
+  catch { die('invalid internal config'); }
+  authenticatedRun(config);
+} else if (command === 'status') status();
+else if (command === 'remove') remove();
+else if (command === 'help' || command === '--help' || command === '-h') usage(0);
+else usage(2);

--- a/hush
+++ b/hush
@@ -204,6 +204,11 @@ hush — a secret store for AI agents. values are never printed.
                                    upsert selected secrets into a KeePassXC database. with no names,
                                    sync all except the database-password secret. options: --init,
                                    --group <name> (default: hush), --exclude <name>, --dry-run
+  hush sync bitwarden [options] [name ...]
+                                   upsert selected secrets into Bitwarden login-password fields.
+                                   requires an unlocked BW_SESSION. with no names, sync all except
+                                   auth secrets. options: --folder <name> (default: hush),
+                                   --exclude <name> (repeatable), --dry-run
   hush file <name> <path>          write the value to a 0600 file (refuses inside a git repo)
   hush list                        list NAMES only, read straight from the store (never values)
   hush rename <old> <new> [--force]   (alias: mv)
@@ -318,8 +323,8 @@ case "$cmd" in
     ;;
   sync)
     backend_check
-    target="${1:-}"; [ -n "$target" ] || die "sync: missing target (supported: lastpass, keepass)"; shift
-    case "$target" in lastpass|keepass) ;; *) die "sync: unsupported target '$target' (supported: lastpass, keepass)" ;; esac
+    target="${1:-}"; [ -n "$target" ] || die "sync: missing target (supported: lastpass, keepass, bitwarden)"; shift
+    case "$target" in lastpass|keepass|bitwarden) ;; *) die "sync: unsupported target '$target' (supported: lastpass, keepass, bitwarden)" ;; esac
 
     if [ "$target" = lastpass ]; then
     group="hush"; dry_run=0; names=(); excludes=()
@@ -398,7 +403,7 @@ case "$cmd" in
       unset __val
       printf 'hush: synced %s -> LastPass %s (value not shown).\n' "$name" "$entry"
     done
-    else
+    elif [ "$target" = keepass ]; then
       database=""; db_secret=""; group="hush"; init=0; dry_run=0; names=(); excludes=()
       while [ $# -gt 0 ]; do
         case "$1" in
@@ -537,6 +542,133 @@ case "$cmd" in
         printf 'hush: created KeePass database %s. keep its password somewhere recoverable.\n' "$database"
       fi
       unset __db
+    else
+      folder="hush"; dry_run=0; names=(); excludes=()
+      auth_names=(bitwarden-client-id bitwarden-client-secret bitwarden-master-password)
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --folder)
+            [ $# -ge 2 ] || die "sync bitwarden: --folder needs a name"
+            folder="$2"; shift 2 ;;
+          --exclude)
+            [ $# -ge 2 ] || die "sync bitwarden: --exclude needs a secret name"
+            excludes+=("$2"); shift 2 ;;
+          --dry-run) dry_run=1; shift ;;
+          --) shift; while [ $# -gt 0 ]; do names+=("$1"); shift; done ;;
+          -*) die "sync bitwarden: unknown option '$1'" ;;
+          *) names+=("$1"); shift ;;
+        esac
+      done
+
+      [ -n "$folder" ] || die "sync bitwarden: --folder cannot be empty"
+      case "$folder" in *$'\n'*) die "sync bitwarden: --folder cannot contain a newline" ;; esac
+      if [ "${#excludes[@]}" -gt 0 ]; then
+        for excluded in "${excludes[@]}"; do
+          [ -n "$excluded" ] || die "sync bitwarden: --exclude cannot be empty"
+          case "$excluded" in *$'\n'*) die "sync bitwarden: --exclude cannot contain a newline" ;; esac
+        done
+      fi
+
+      bw="${HUSH_BITWARDEN:-bw}"
+      node="${HUSH_NODE:-node}"
+      hush_source="$("$node" -e 'process.stdout.write(require("node:fs").realpathSync(process.argv[1]))' "${BASH_SOURCE[0]:-$0}")" ||
+        die "sync bitwarden: could not resolve the hush install path"
+      hush_dir="$(dirname "$hush_source")"
+      bw_json="${HUSH_BITWARDEN_JSON:-$hush_dir/helpers/hush-bitwarden-json.mjs}"
+      command -v "$bw" >/dev/null 2>&1 || die "sync bitwarden: '$bw' is required (install bitwarden-cli)"
+      command -v "$node" >/dev/null 2>&1 || die "sync bitwarden: '$node' is required"
+      [ -f "$bw_json" ] || die "sync bitwarden: JSON helper not found at '$bw_json'"
+      "$bw" status 2>/dev/null | "$node" "$bw_json" status >/dev/null 2>&1 ||
+        die "sync bitwarden: vault is not unlocked (set BW_SESSION or use hush-bitwarden-schedule)"
+      "$bw" sync >/dev/null 2>&1 || die "sync bitwarden: server sync failed before write"
+
+      if [ "${#names[@]}" -eq 0 ]; then
+        while IFS= read -r name; do [ -n "$name" ] && names+=("$name"); done < <(b_list)
+      fi
+      [ "${#names[@]}" -gt 0 ] || die "sync bitwarden: no hush secrets found in namespace '$NS'"
+
+      selected=()
+      for name in "${names[@]}"; do
+        skip=0
+        for auth_name in "${auth_names[@]}"; do [ "$name" = "$auth_name" ] && skip=1; done
+        if [ "${#excludes[@]}" -gt 0 ]; then
+          for excluded in "${excludes[@]}"; do [ "$name" = "$excluded" ] && skip=1; done
+        fi
+        [ "$skip" -eq 1 ] || selected+=("$name")
+      done
+      if [ "${#selected[@]}" -eq 0 ]; then
+        printf 'hush: no Bitwarden sync candidates remain after exclusions.\n'
+        exit 0
+      fi
+      names=("${selected[@]}")
+
+      for name in "${names[@]}"; do
+        [ -n "$name" ] || die "sync bitwarden: secret names cannot be empty"
+        case "$name" in *$'\n'*) die "sync bitwarden: secret names cannot contain a newline ('$name')" ;; esac
+        b_exists "$name" || die "sync bitwarden: no secret named '$name' (try: hush list)"
+      done
+
+      folder_id=""
+      folder_rc=0
+      folder_id="$("$bw" list folders 2>/dev/null | "$node" "$bw_json" folder "$folder")" || folder_rc=$?
+      [ "$folder_rc" -ne 3 ] || die "sync bitwarden: duplicate folder '$folder'"
+      [ "$folder_rc" -eq 0 ] || die "sync bitwarden: could not inspect folders"
+
+      actions=(); ids=()
+      if [ -z "$folder_id" ]; then
+        for name in "${names[@]}"; do actions+=(create); ids+=(""); done
+      else
+        for name in "${names[@]}"; do
+          item_id=""; item_rc=0
+          item_id="$("$bw" list items --search "$name" 2>/dev/null | "$node" "$bw_json" item "$name" "$folder_id")" || item_rc=$?
+          [ "$item_rc" -ne 3 ] || die "sync bitwarden: duplicate item '$folder/$name'"
+          [ "$item_rc" -eq 0 ] || die "sync bitwarden: could not inspect '$folder/$name'"
+          if [ -n "$item_id" ]; then actions+=(edit); else actions+=(create); fi
+          ids+=("$item_id")
+        done
+      fi
+
+      if [ "$dry_run" -eq 1 ]; then
+        [ -n "$folder_id" ] || printf 'hush: would create Bitwarden folder %s.\n' "$folder"
+        i=0
+        for name in "${names[@]}"; do
+          printf 'hush: would %s %s -> Bitwarden %s/%s (value not read).\n' "${actions[$i]}" "$name" "$folder" "$name"
+          i=$((i + 1))
+        done
+        exit 0
+      fi
+
+      if [ -z "$folder_id" ]; then
+        folder_id="$("$bw" get template folder 2>/dev/null |
+          "$node" "$bw_json" folder-create "$folder" |
+          "$bw" create folder 2>/dev/null |
+          "$node" "$bw_json" id)" ||
+          die "sync bitwarden: could not create folder '$folder'"
+      fi
+
+      i=0
+      for name in "${names[@]}"; do
+        __val=""
+        b_fetch "$name" __val
+        if [ "${actions[$i]}" = create ]; then
+          if ! "$bw" get template item 2>/dev/null |
+            HUSH_BITWARDEN_VALUE="$__val" "$node" "$bw_json" item-create "$name" "$folder_id" |
+            "$bw" create item >/dev/null 2>&1; then
+            unset __val
+            die "sync bitwarden: Bitwarden rejected create '$folder/$name'; no value was shown"
+          fi
+        else
+          if ! "$bw" get item "${ids[$i]}" 2>/dev/null |
+            HUSH_BITWARDEN_VALUE="$__val" "$node" "$bw_json" item-update "$name" "$folder_id" |
+            "$bw" edit item "${ids[$i]}" >/dev/null 2>&1; then
+            unset __val
+            die "sync bitwarden: Bitwarden rejected update '$folder/$name'; no value was shown"
+          fi
+        fi
+        unset __val
+        printf 'hush: synced %s -> Bitwarden %s/%s (value not shown).\n' "$name" "$folder" "$name"
+        i=$((i + 1))
+      done
     fi
     ;;
   file)

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "a secret store for AI agents with one rule: the agent never sees the plaintext. get a secret once into the OS keychain, then inject it into commands forever. no get, cross-platform, MIT.",
   "bin": {
     "hush": "hush",
+    "hush-bitwarden-schedule": "helpers/hush-bitwarden-schedule.mjs",
     "hush-lastpass-schedule": "helpers/hush-lastpass-schedule.mjs",
     "hush-keepass-schedule": "helpers/hush-keepass-schedule.mjs"
   },
   "files": [
     "hush",
+    "helpers/hush-bitwarden-json.mjs",
+    "helpers/hush-bitwarden-schedule.mjs",
     "helpers/hush-lastpass-schedule.mjs",
     "helpers/hush-keepass-schedule.mjs",
     "win/hush-backend.ps1",

--- a/test/bitwarden-live.sh
+++ b/test/bitwarden-live.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Opt-in integration test. Requires real Bitwarden CLI auth secrets in the default hush namespace.
+set -eu
+set +x
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+hush="$repo/hush"
+bw="${HUSH_BITWARDEN:-bw}"
+helper="$repo/helpers/hush-bitwarden-json.mjs"
+namespace="hush-bitwarden-live-$$"
+entry="hush-live-entry-$$"
+folder="hush"
+
+cleanup() {
+  HUSH_NS="$namespace" "$hush" rm "$entry" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT HUP INT TERM
+
+command -v "$bw" >/dev/null 2>&1 || { printf 'bw is required\n' >&2; exit 1; }
+openssl rand -hex 32 | HUSH_NS="$namespace" "$hush" set "$entry" --pipe >/dev/null
+
+sync_verify() {
+  delete_after="$1"
+  HUSH_NS=hush "$hush" run \
+    BW_CLIENTID=bitwarden-client-id \
+    BW_CLIENTSECRET=bitwarden-client-secret \
+    BW_PASSWORD=bitwarden-master-password -- \
+    env HUSH_NS="$namespace" "$hush" run EXPECTED="$entry" -- \
+    sh -c '
+      session="$("$1" unlock --passwordenv BW_PASSWORD --raw)" || exit 1
+      export BW_SESSION="$session" HUSH_BITWARDEN="$1" HUSH_BITWARDEN_JSON="$2"
+      "$3" sync bitwarden --folder "$4" "$5" >/dev/null
+      item_id="$("$1" list items --search "$5" |
+        EXPECTED="$EXPECTED" node -e '\''
+          let s = "";
+          process.stdin.on("data", d => s += d).on("end", () => {
+            const [name] = process.argv.slice(1);
+            const matches = JSON.parse(s).filter(x => x.name === name);
+            if (matches.length !== 1 || matches[0].login.password !== process.env.EXPECTED) process.exit(1);
+            process.stdout.write(matches[0].id);
+          });
+        '\'' "$5")" || exit 1
+      if [ "$6" = yes ]; then "$1" delete item "$item_id" --permanent >/dev/null; fi
+      "$1" lock >/dev/null
+    ' sh "$bw" "$helper" "$hush" "$folder" "$entry" "$delete_after"
+}
+
+sync_verify no
+openssl rand -hex 32 | HUSH_NS="$namespace" "$hush" set "$entry" --pipe >/dev/null
+sync_verify yes
+
+printf 'ok   - real Bitwarden create and update preserve values without printing them\n'

--- a/test/bitwarden-schedule.mjs
+++ b/test/bitwarden-schedule.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repo = fileURLToPath(new URL('..', import.meta.url));
+const helper = join(repo, 'helpers', 'hush-bitwarden-schedule.mjs');
+const root = mkdtempSync(join(tmpdir(), 'hush-bitwarden-schedule-'));
+const log = join(root, 'commands.log');
+const names = join(root, 'hush-names');
+const authState = join(root, 'bw-authenticated');
+const launchState = join(root, 'launch-loaded');
+const hush = join(root, 'hush');
+const bw = join(root, 'bw');
+const launchctl = join(root, 'launchctl');
+
+function script(path, content) {
+  writeFileSync(path, `#!/usr/bin/env bash\nset -u\n${content}\n`, { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+script(hush, `
+printf 'hush:%s\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  list) cat "$HUSH_TEST_NAMES" ;;
+  set) printf '%s\n' "$2" >> "$HUSH_TEST_NAMES" ;;
+  run)
+    shift
+    while [ "$1" != -- ]; do
+      key="\${1%%=*}"; name="\${1#*=}"
+      case "$name" in
+        bitwarden-client-id) value='client-value' ;;
+        bitwarden-client-secret) value='secret-value' ;;
+        bitwarden-master-password) value='master-value' ;;
+        *) exit 41 ;;
+      esac
+      export "$key=$value"
+      shift
+    done
+    shift
+    "$@" ;;
+  sync)
+    printf 'sync-env:session=%s:credentials=%s\n' "\${BW_SESSION:+present}" "\${BW_PASSWORD:+present}\${BW_CLIENTID:+present}\${BW_CLIENTSECRET:+present}" >> "$HUSH_TEST_LOG"
+    exit "\${HUSH_TEST_SYNC_RC:-0}" ;;
+  *) exit 42 ;;
+esac`);
+
+script(bw, `
+printf 'bw:%s\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  status)
+    if [ -f "$HUSH_TEST_AUTH_STATE" ]; then printf '{"status":"locked"}\n'; else printf '{"status":"unauthenticated"}\n'; fi ;;
+  login)
+    [ "\${BW_CLIENTID:-}" = client-value ] && [ "\${BW_CLIENTSECRET:-}" = secret-value ] || exit 51
+    : > "$HUSH_TEST_AUTH_STATE" ;;
+  unlock)
+    [ "\${BW_PASSWORD:-}" = master-value ] || exit 52
+    printf 'session-value\n' ;;
+  lock) : ;;
+  *) exit 53 ;;
+esac`);
+
+script(launchctl, `
+printf 'launchctl:%s\n' "$*" >> "$HUSH_TEST_LOG"
+case "\${1:-}" in
+  bootstrap) : > "$HUSH_TEST_LAUNCH_STATE" ;;
+  bootout) rm -f "$HUSH_TEST_LAUNCH_STATE" ;;
+  print) [ -f "$HUSH_TEST_LAUNCH_STATE" ] ;;
+  *) exit 54 ;;
+esac`);
+
+writeFileSync(names, 'bitwarden-client-id\nbitwarden-client-secret\n');
+const env = {
+  ...process.env,
+  HUSH_BITWARDEN_SCHEDULE_HOME: root,
+  HUSH_BITWARDEN_SCHEDULE_PLATFORM: 'darwin',
+  HUSH_BITWARDEN_SCHEDULE_HUSH: hush,
+  HUSH_BITWARDEN_SCHEDULE_BW: bw,
+  HUSH_BITWARDEN_SCHEDULE_LAUNCHCTL: launchctl,
+  HUSH_TEST_LOG: log,
+  HUSH_TEST_NAMES: names,
+  HUSH_TEST_AUTH_STATE: authState,
+  HUSH_TEST_LAUNCH_STATE: launchState,
+};
+
+function invoke(args, extraEnv = {}) {
+  return spawnSync(process.execPath, [helper, ...args], {
+    env: { ...env, ...extraEnv },
+    encoding: 'utf8',
+  });
+}
+
+function ok(label) { process.stdout.write(`ok   - ${label}\n`); }
+
+try {
+  let result = invoke(['install', '--every', '6h', '--folder', 'hush', '--exclude', 'local-only', 'selected-a']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  ok('cold schedule install authenticates, unlocks, previews, and loads');
+
+  const configPath = join(root, 'Library', 'Application Support', 'hush', 'bitwarden-schedule.json');
+  const plistPath = join(root, 'Library', 'LaunchAgents', 'com.royashbrook.hush.bitwarden-sync.plist');
+  const config = JSON.parse(readFileSync(configPath, 'utf8'));
+  assert.equal(config.clientIdSecret, 'bitwarden-client-id');
+  assert.equal(config.clientSecretSecret, 'bitwarden-client-secret');
+  assert.equal(config.masterSecret, 'bitwarden-master-password');
+  assert.deepEqual(config.excludes, ['local-only']);
+  assert.deepEqual(config.names, ['selected-a']);
+  assert.equal(config.seconds, 21600);
+  assert.equal(statSync(configPath).mode & 0o777, 0o600);
+  const configText = readFileSync(configPath, 'utf8');
+  for (const value of ['client-value', 'secret-value', 'master-value', 'session-value']) {
+    assert.ok(!configText.includes(value));
+  }
+  ok('config is mode 0600 metadata only');
+
+  const plist = readFileSync(plistPath, 'utf8');
+  assert.match(plist, /<integer>21600<\/integer>/);
+  assert.match(plist, /<string>run<\/string>/);
+  assert.ok(!plist.includes('bitwarden-client-id'));
+  assert.ok(!plist.includes('bitwarden-master-password'));
+  ok('LaunchAgent contains only runner and config paths');
+
+  let commands = readFileSync(log, 'utf8');
+  assert.match(commands, /hush:set bitwarden-master-password/);
+  assert.match(commands, /bw:login --apikey/);
+  assert.match(commands, /bw:unlock --passwordenv BW_PASSWORD --raw/);
+  assert.match(commands, /hush:sync bitwarden --folder hush .*--dry-run selected-a/);
+  assert.match(commands, /sync-env:session=present:credentials=/);
+  assert.match(commands, /launchctl:bootstrap gui\/\d+ /);
+  for (const value of ['client-value', 'secret-value', 'master-value', 'session-value']) {
+    assert.ok(!commands.includes(value));
+  }
+  ok('credential values stay out of argv, config, plist, and logs');
+
+  writeFileSync(log, '');
+  result = invoke(['run']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  commands = readFileSync(log, 'utf8');
+  assert.ok(!commands.includes('bw:login'));
+  assert.match(commands, /bw:unlock --passwordenv BW_PASSWORD --raw/);
+  assert.match(commands, /hush:sync bitwarden --folder hush .* selected-a/);
+  assert.match(result.stdout, /sync ok/);
+  ok('scheduled run reuses API login and obtains a fresh short-lived session');
+
+  result = invoke(['status']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /loaded, every 6h, folder hush/);
+  ok('status reports loaded schedule');
+
+  result = invoke(['remove']);
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(existsSync(plistPath), false);
+  assert.equal(existsSync(configPath), true);
+  ok('remove unloads launchd and retains metadata plus hush credentials');
+
+  process.stdout.write('# Bitwarden schedule tests done. failures: 0\n');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/test/bitwarden-sync.sh
+++ b/test/bitwarden-sync.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Deterministic Bitwarden sync tests. OS storage and bw are fakes, so no real keychain or vault is touched.
+set -uo pipefail
+
+HUSH="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)/hush"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+STUB="$(mktemp -d 2>/dev/null || echo "${TMPDIR:-/tmp}/hush-bitwarden-test-$$")"
+STORE="$STUB/store"
+export HUSH_TEST_STORE="$STORE"
+export HUSH_SECURITY_LOG="$STUB/security.log"
+export HUSH_BW_LOG="$STUB/bw.log"
+export HUSH_BW_STATE="$STUB/bw-state.json"
+export HUSH_NS="hush-bitwarden-test-$$"
+export HUSH_BITWARDEN="$STUB/bw"
+export HUSH_BITWARDEN_JSON="$ROOT/helpers/hush-bitwarden-json.mjs"
+SENTINEL="BW-S3NT-$$-never-log-this"
+fails=0
+
+mkdir -p "$STORE"
+cleanup() { rm -rf "$STUB" 2>/dev/null; }
+trap cleanup EXIT
+ok()  { printf 'ok   - %s\n' "$1"; }
+bad() { printf 'FAIL - %s\n' "$1"; fails=$((fails + 1)); }
+run_hush() { env PATH="$STUB:$PATH" "$HUSH" "$@"; }
+
+printf '%s\n' '#!/bin/sh' \
+  'if [ "${1:-}" = -s ]; then printf "Darwin\n"; else /usr/bin/uname "$@"; fi' > "$STUB/uname"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+  'set -u' \
+  'verb="${1:-}"; shift || true' \
+  'service=""; value=""; bare_w=0' \
+  'while [ $# -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -s) service="$2"; shift 2 ;;' \
+  '    -w) if [ $# -gt 1 ]; then value="$2"; shift 2; else bare_w=1; shift; fi ;;' \
+  '    *) shift ;;' \
+  '  esac' \
+  'done' \
+  'case "$verb" in' \
+  '  add-generic-password)' \
+  '    if [ "$bare_w" -eq 1 ]; then IFS= read -r value || true; IFS= read -r confirm || true; [ "$value" = "$confirm" ] || exit 46; fi' \
+  '    printf "%s" "$value" > "$HUSH_TEST_STORE/$service" ;;' \
+  '  find-generic-password)' \
+  '    [ -f "$HUSH_TEST_STORE/$service" ] || exit 44' \
+  '    if [ "$bare_w" -eq 1 ]; then printf "fetch:%s\n" "$service" >> "$HUSH_SECURITY_LOG"; cat "$HUSH_TEST_STORE/$service"; fi ;;' \
+  '  delete-generic-password) rm -f "$HUSH_TEST_STORE/$service" ;;' \
+  '  dump-keychain)' \
+  '    for item in "$HUSH_TEST_STORE"/*; do' \
+  '      [ -f "$item" ] || continue' \
+  "      printf '    \"svce\"<blob>=\"%s\"\\n' \"\${item##*/}\"" \
+  '    done ;;' \
+  '  *) exit 45 ;;' \
+  'esac' > "$STUB/security"
+
+cat > "$STUB/bw" <<'NODE'
+#!/usr/bin/env node
+import fs from 'node:fs';
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.HUSH_BW_LOG, `bw:${args.join(' ')}\n`);
+const read = () => fs.readFileSync(0, 'utf8');
+const load = () => JSON.parse(fs.readFileSync(process.env.HUSH_BW_STATE, 'utf8'));
+const save = (value) => fs.writeFileSync(process.env.HUSH_BW_STATE, JSON.stringify(value));
+const out = (value) => process.stdout.write(JSON.stringify(value));
+const [verb, noun, ...rest] = args;
+if (verb === 'status') out({ status: process.env.HUSH_BW_LOCKED === '1' ? 'locked' : 'unlocked' });
+else if (verb === 'sync') process.exit(0);
+else if (verb === 'list' && noun === 'folders') {
+  out(process.env.HUSH_BW_NO_FOLDER === '1' ? [] : load().folders);
+} else if (verb === 'list' && noun === 'items') {
+  const state = load();
+  const at = rest.indexOf('--search');
+  const name = at >= 0 ? rest[at + 1] : '';
+  const matches = state.items.filter((item) => item.name.includes(name));
+  if (process.env.HUSH_BW_DUPLICATE === '1' && name === 'sync-a' && matches[0]) {
+    matches.push({ ...matches[0], id: 'duplicate-id' });
+  }
+  out(matches);
+} else if (verb === 'get' && noun === 'template' && rest[0] === 'folder') {
+  out({ name: null });
+} else if (verb === 'get' && noun === 'template' && rest[0] === 'item') {
+  out({ type: 1, name: null, folderId: null, login: { username: null, password: null } });
+} else if (verb === 'get' && noun === 'item') {
+  const item = load().items.find((value) => value.id === rest[0]);
+  if (!item) process.exit(50);
+  out(item);
+} else if (verb === 'create' && noun === 'folder') {
+  const state = load();
+  const folder = { ...JSON.parse(Buffer.from(read(), 'base64').toString('utf8')), id: 'folder-created' };
+  state.folders.push(folder); save(state); out(folder);
+} else if (verb === 'create' && noun === 'item') {
+  const state = load();
+  const item = { ...JSON.parse(Buffer.from(read(), 'base64').toString('utf8')), id: `item-${state.items.length + 1}` };
+  if (item.name === 'sync-a' && item.login.password !== process.env.HUSH_BW_EXPECT) process.exit(51);
+  state.items.push(item); save(state); fs.appendFileSync(process.env.HUSH_BW_LOG, 'value-ok\n'); out(item);
+} else if (verb === 'edit' && noun === 'item') {
+  const state = load();
+  const item = JSON.parse(Buffer.from(read(), 'base64').toString('utf8'));
+  if (item.name === 'sync-a' && item.login.password !== process.env.HUSH_BW_EXPECT) process.exit(52);
+  const at = state.items.findIndex((value) => value.id === rest[0]);
+  if (at < 0) process.exit(53);
+  state.items[at] = item; save(state); fs.appendFileSync(process.env.HUSH_BW_LOG, 'value-ok\n'); out(item);
+} else process.exit(54);
+NODE
+
+chmod +x "$STUB/uname" "$STUB/security" "$STUB/bw"
+printf '%s' '{"folders":[{"id":"folder-1","name":"hush"}],"items":[{"id":"item-1","name":"sync-a","folderId":"folder-1","type":1,"login":{"password":"REMOTE-OLD-NEVER-LOG"}}]}' > "$HUSH_BW_STATE"
+export HUSH_BW_EXPECT="$SENTINEL"
+
+printf '%s' "$SENTINEL" | run_hush set sync-a --pipe >/dev/null 2>&1
+run_hush mint sync-b --bytes 4 >/dev/null 2>&1
+printf '%s' 'CLIENT-ID-NEVER-SYNC' | run_hush set bitwarden-client-id --pipe >/dev/null 2>&1
+printf '%s' 'CLIENT-SECRET-NEVER-SYNC' | run_hush set bitwarden-client-secret --pipe >/dev/null 2>&1
+printf '%s' 'MASTER-NEVER-SYNC' | run_hush set bitwarden-master-password --pipe >/dev/null 2>&1
+printf '%s' 'LOCAL-ONLY' | run_hush set local-only --pipe >/dev/null 2>&1
+
+: > "$HUSH_BW_LOG"; : > "$HUSH_SECURITY_LOG"
+out="$(run_hush sync bitwarden --dry-run sync-a 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "dry-run succeeds" || bad "dry-run failed (got: $out)"
+printf '%s' "$out" | grep -q 'would edit sync-a' && ok "dry-run identifies update" || bad "dry-run action wrong"
+[ ! -s "$HUSH_SECURITY_LOG" ] && ok "dry-run fetches no hush values" || bad "dry-run fetched a value"
+
+: > "$HUSH_BW_LOG"; : > "$HUSH_SECURITY_LOG"
+out="$(run_hush sync bitwarden sync-a 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "existing item update succeeds" || bad "update failed (got: $out)"
+grep -q '^bw:edit item item-1$' "$HUSH_BW_LOG" && grep -q '^value-ok$' "$HUSH_BW_LOG" && ok "unique item is safely edited" || bad "edit contract wrong"
+grep -qF "$SENTINEL" "$HUSH_BW_LOG" && bad "value reached Bitwarden argv/log" || ok "value stays out of Bitwarden argv/log"
+printf '%s' "$out" | grep -qF "$SENTINEL" && bad "value leaked in output" || ok "success output does not leak"
+
+: > "$HUSH_BW_LOG"
+out="$(run_hush sync bitwarden sync-b 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && grep -q '^bw:create item$' "$HUSH_BW_LOG" && ok "missing item is created" || bad "create failed (got: $out)"
+
+: > "$HUSH_BW_LOG"
+out="$(run_hush sync bitwarden --exclude local-only 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "bulk sync with exclusion succeeds" || bad "bulk sync failed (got: $out)"
+printf '%s' "$out" | grep -Eq 'bitwarden-client|bitwarden-master|local-only' && bad "auth or excluded name was selected" || ok "auth defaults and explicit exclusions stay local"
+
+: > "$HUSH_BW_LOG"
+out="$(run_hush sync bitwarden sync-a does-not-exist 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "missing selection fails" || bad "missing selection accepted"
+grep -Eq '^bw:(create|edit) ' "$HUSH_BW_LOG" && bad "write happened before local validation" || ok "all local names validate before write"
+
+: > "$HUSH_BW_LOG"
+out="$(HUSH_BW_DUPLICATE=1 run_hush sync bitwarden sync-a 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "duplicate item fails closed" || bad "duplicate item accepted"
+grep -Eq '^bw:(create|edit) ' "$HUSH_BW_LOG" && bad "duplicate item was written" || ok "duplicate detection precedes write"
+
+: > "$HUSH_BW_LOG"
+out="$(HUSH_BW_LOCKED=1 run_hush sync bitwarden sync-a 2>&1)"; rc=$?
+[ "$rc" -ne 0 ] && ok "locked vault fails closed" || bad "locked vault accepted"
+grep -Eq '^bw:(create|edit) ' "$HUSH_BW_LOG" && bad "locked vault was written" || ok "unlock check precedes write"
+
+run_hush mint sync-c --bytes 4 >/dev/null 2>&1
+: > "$HUSH_BW_LOG"
+out="$(HUSH_BW_NO_FOLDER=1 run_hush sync bitwarden --folder fresh sync-c 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && grep -q '^bw:create folder$' "$HUSH_BW_LOG" && grep -q '^bw:create item$' "$HUSH_BW_LOG" && ok "missing folder is created before item" || bad "folder create failed (got: $out)"
+
+printf '# Bitwarden sync tests done. failures: %s\n' "$fails"
+exit "$fails"

--- a/test/test.sh
+++ b/test/test.sh
@@ -145,5 +145,17 @@ else
   bad "isolated KeePass schedule suite"
 fi
 
+if bash "$(dirname "${BASH_SOURCE[0]:-$0}")/bitwarden-sync.sh"; then
+  ok "isolated Bitwarden sync suite"
+else
+  bad "isolated Bitwarden sync suite"
+fi
+
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/bitwarden-schedule.mjs"; then
+  ok "isolated Bitwarden schedule suite"
+else
+  bad "isolated Bitwarden schedule suite"
+fi
+
 echo "# done. failures: $fails"
 [ "$fails" -eq 0 ]


### PR DESCRIPTION
Adds one-way hush to Bitwarden login-password upserts plus an npm-shipped macOS launchd helper. API-key credentials authenticate the CLI; a separately opted-in master-password secret unlocks each short-lived session. Auth secrets are forcibly excluded, encoded item bodies flow over stdin, duplicate exact names fail closed, and no credential/session reaches argv, logs, plist, config, stdout, or temp files.\n\nVerified with the full macOS suite, deterministic core/auth/scheduler suites, npm pack inspection, and a disposable live Bitwarden create/update/value-compare/permanent-delete cycle.\n\nCloses #13