### PR TITLE
fix: keep scheduled KeePass sync out of CloudDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,12 @@ hush-keepass-schedule install --every 6h
 hush-keepass-schedule status
 ```
 
-The default destination is `iCloud Drive/hush/hush.kdbx`. Use `--database`, `--db-secret`, `--group`,
-repeatable `--exclude`, or positional names to narrow it. `remove` unloads the LaunchAgent but keeps
-the database and mode-0600 metadata config.
+The default destination is `iCloud Drive/hush/hush.kdbx`. Scheduled runs update an encrypted local
+mirror under `Application Support/hush`, then atomically publish a completed copy. KeePassXC never
+opens CloudDocs from launchd, avoiding macOS's headless iCloud privacy block. A publish that takes
+more than 30 seconds fails with an actionable error instead of hanging. Use `--database`,
+`--db-secret`, `--group`, repeatable `--exclude`, or positional names to narrow it. `remove` unloads
+the LaunchAgent but keeps the destination, local mirror, and mode-0600 metadata config.
 
 Keep one durable copy of the database password outside this KDBX. After a machine loss, the iCloud
 file cannot recover the hush secret that unlocks it. Treat one machine as the writer while iCloud is

--- a/SKILL.md
+++ b/SKILL.md
@@ -186,9 +186,11 @@ hush-keepass-schedule remove
 ```
 
 Install creates and populates an absent database. If the database-password secret does not exist,
-it invokes hush's hidden prompt. Keep a separate durable copy of that password, because a recovered
-KDBX cannot recover the local hush secret needed to open it. Avoid simultaneous writers while the
-file is syncing through iCloud.
+it invokes hush's hidden prompt. Scheduled runs update an encrypted local mirror, then atomically
+publish a completed KDBX to iCloud; KeePassXC never opens CloudDocs headlessly. A blocked publish
+times out after 30 seconds. Keep a separate durable copy of the password, because a recovered KDBX
+cannot recover the local hush secret needed to open it. Avoid simultaneous writers while iCloud
+syncs the file.
 
 For a hosted Bitwarden copy, use the official bw CLI. API-key login needs the client ID and client
 secret, but Bitwarden still requires the master password to unlock vault data:

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -36,12 +36,15 @@ hush-keepass-schedule remove
 
 The default database is `iCloud Drive/hush/hush.kdbx`. Setup asks through hush for
 `hush-keepass-master-password` when absent, creates and populates an absent database, then stores
-only mode-0600 metadata in its config. Use `--database`, `--db-secret`, `--group`, repeatable
-`--exclude`, and positional secret names to change the selection.
+only mode-0600 metadata in its config. Scheduled runs update an encrypted local mirror under
+`Application Support/hush` and atomically publish the completed KDBX. KeePassXC never opens
+CloudDocs headlessly; a blocked publish times out after 30 seconds. Use `--database`, `--db-secret`,
+`--group`, repeatable `--exclude`, and positional secret names to change the selection.
 
 Database and entry passwords travel to `keepassxc-cli` only on stdin. The database-password secret
-is always excluded from sync. `remove` unloads launchd while retaining the KDBX and config. Keep a
-separate durable copy of the database password and avoid simultaneous iCloud writers.
+is always excluded from sync. `remove` unloads launchd while retaining the destination KDBX, local
+mirror, and config. Keep a separate durable copy of the database password and avoid simultaneous
+iCloud writers.
 
 ## hush-bitwarden-schedule, unattended hosted-vault sync (macOS)
 

--- a/helpers/hush-keepass-schedule.mjs
+++ b/helpers/hush-keepass-schedule.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, delimiter, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -32,7 +32,9 @@ options:
   --every <Nm|Nh|Nd>      interval, minimum 5m (default: 6h)
 
 install creates the database when absent and prompts through hush if the database password secret
-does not exist. keep a separate durable copy of that password: the kdbx cannot recover itself.
+does not exist. scheduled runs update a local encrypted mirror, then publish a completed copy to
+iCloud so KeePassXC never opens CloudDocs headlessly. keep a separate durable copy of the database
+password: the kdbx cannot recover itself.
 `);
   process.exit(code);
 }
@@ -64,6 +66,7 @@ function run(program, args, options = {}) {
     encoding: 'utf8',
     env: options.env || process.env,
     stdio: options.stdio || 'pipe',
+    timeout: options.timeout,
   });
 }
 
@@ -125,9 +128,9 @@ function parseInstall(args, home) {
   return result;
 }
 
-function syncArgs(config, mode = '') {
+function syncArgs(config, mode = '', database = config.mirror || config.database) {
   const args = [
-    'sync', 'keepass', '--database', config.database,
+    'sync', 'keepass', '--database', database,
     '--db-secret', config.dbSecret, '--group', config.group,
   ];
   for (const name of config.excludes) args.push('--exclude', name);
@@ -135,6 +138,28 @@ function syncArgs(config, mode = '') {
   else if (mode === 'dry-run') args.push('--dry-run');
   args.push(...config.names);
   return args;
+}
+
+function publishDatabase(config) {
+  if (!existsSync(config.mirror)) die(`local mirror is missing: ${config.mirror}`);
+  const temp = join(dirname(config.mirror), `.${basename(config.database)}.${process.pid}.publish`);
+  rmSync(temp, { force: true });
+  let error = '';
+  try {
+    copyFileSync(config.mirror, temp);
+    chmodSync(temp, 0o600);
+    const published = run('/bin/mv', ['-f', temp, config.database], { timeout: 30000 });
+    if (published.error?.code === 'ETIMEDOUT') {
+      error = `publishing to iCloud timed out after 30s: ${config.database}`;
+    } else if (published.status !== 0) {
+      error = `could not publish database to: ${config.database}`;
+    }
+  } catch {
+    error = `could not stage database for publishing: ${config.database}`;
+  } finally {
+    rmSync(temp, { force: true });
+  }
+  if (error) die(error);
 }
 
 function readConfig(path) {
@@ -152,8 +177,9 @@ function install(args) {
   const keepassxc = findExecutable('keepassxc-cli', process.env.HUSH_KEEPASS_SCHEDULE_KEEPASSXC);
   const launchctl = findExecutable('launchctl', process.env.HUSH_KEEPASS_SCHEDULE_LAUNCHCTL);
   const config = {
-    version: 1, hush, keepassxc,
+    version: 2, hush, keepassxc,
     database: options.database, dbSecret: options.dbSecret, group: options.group,
+    mirror: join(dirname(paths.config), 'keepass-mirror.kdbx'),
     excludes: options.excludes, names: options.names,
     every: options.every, seconds: options.seconds,
   };
@@ -167,14 +193,25 @@ function install(args) {
     if (stored.status !== 0) die('database password was not stored; nothing installed');
   }
 
+  try {
+    mkdirSync(dirname(config.mirror), { recursive: true, mode: 0o700 });
+    mkdirSync(dirname(config.database), { recursive: true, mode: 0o700 });
+  } catch { die('could not create the local mirror or destination directory'); }
   let mode = 'dry-run';
-  if (!existsSync(config.database)) {
-    try { mkdirSync(dirname(config.database), { recursive: true, mode: 0o700 }); }
-    catch { die(`could not create database directory: ${dirname(config.database)}`); }
-    mode = 'init';
+  if (!existsSync(config.mirror)) {
+    if (existsSync(config.database)) {
+      try {
+        copyFileSync(config.database, config.mirror);
+        chmodSync(config.mirror, 0o600);
+      } catch { die(`could not seed local mirror from: ${config.database}`); }
+    } else {
+      mode = 'init';
+    }
   }
   const preview = run(hush, syncArgs(config, mode), { env, stdio: 'inherit' });
   if (preview.status !== 0) die(`${mode === 'init' ? 'initial sync' : 'sync dry-run'} failed; nothing installed`);
+  chmodSync(config.mirror, 0o600);
+  publishDatabase(config);
 
   writeAtomic(paths.config, `${JSON.stringify(config, null, 2)}\n`);
   mkdirSync(dirname(paths.log), { recursive: true });
@@ -209,10 +246,13 @@ function install(args) {
 
 function scheduledRun(configPath) {
   const config = readConfig(configPath);
-  if (!existsSync(config.database)) die(`database is missing: ${config.database}`);
+  if (config.version !== 2 || !config.mirror) die('schedule config needs migration; run install again');
+  if (!existsSync(config.mirror)) die(`local mirror is missing: ${config.mirror}`);
   const env = { ...process.env, HUSH_KEEPASSXC: config.keepassxc };
-  const synced = run(config.hush, syncArgs(config), { env });
+  const synced = run(config.hush, syncArgs(config), { env, timeout: 300000 });
+  if (synced.error?.code === 'ETIMEDOUT') die('local KeePass sync timed out after 5m');
   if (synced.status !== 0) die(`sync failed with exit ${synced.status}`);
+  publishDatabase(config);
   process.stdout.write(`hush-keepass-schedule: ${new Date().toISOString()} sync ok\n`);
 }
 
@@ -230,7 +270,7 @@ function remove() {
   const launchctl = findExecutable('launchctl', process.env.HUSH_KEEPASS_SCHEDULE_LAUNCHCTL);
   run(launchctl, ['bootout', `gui/${process.getuid()}`, paths.plist]);
   rmSync(paths.plist, { force: true });
-  process.stdout.write(`hush-keepass-schedule: removed LaunchAgent. database and config retained at ${paths.config}.\n`);
+  process.stdout.write(`hush-keepass-schedule: removed LaunchAgent. destination, local mirror, and config retained at ${paths.config}.\n`);
 }
 
 const [command = 'help', ...args] = process.argv.slice(2);

--- a/test/keepass-schedule.mjs
+++ b/test/keepass-schedule.mjs
@@ -82,7 +82,12 @@ try {
   const configPath = join(root, 'Library', 'Application Support', 'hush', 'keepass-schedule.json');
   const plistPath = join(root, 'Library', 'LaunchAgents', 'com.royashbrook.hush.keepass-sync.plist');
   const config = JSON.parse(readFileSync(configPath, 'utf8'));
+  const mirror = join(root, 'Library', 'Application Support', 'hush', 'keepass-mirror.kdbx');
+  assert.equal(config.version, 2);
   assert.equal(config.database, database);
+  assert.equal(config.mirror, mirror);
+  assert.equal(existsSync(mirror), true);
+  assert.equal(statSync(mirror).mode & 0o777, 0o600);
   assert.equal(config.dbSecret, 'hush-keepass-master-password');
   assert.deepEqual(config.excludes, ['local-only']);
   assert.deepEqual(config.names, ['selected-a']);
@@ -100,7 +105,7 @@ try {
 
   let commands = readFileSync(log, 'utf8');
   assert.match(commands, /hush:set hush-keepass-master-password/);
-  assert.match(commands, /hush:sync keepass --database .*hush\.kdbx --db-secret hush-keepass-master-password --group hush --exclude local-only --init selected-a/);
+  assert.match(commands, /hush:sync keepass --database .*keepass-mirror\.kdbx --db-secret hush-keepass-master-password --group hush --exclude local-only --init selected-a/);
   assert.match(commands, /launchctl:bootstrap gui\/\d+ /);
   assert.ok(!commands.includes('database-password-value'));
   ok('install stores the password, initializes once, then loads launchd');
@@ -109,7 +114,9 @@ try {
   result = invoke(['run']);
   assert.equal(result.status, 0, result.stderr || result.stdout);
   commands = readFileSync(log, 'utf8');
-  assert.match(commands, /hush:sync keepass --database .*hush\.kdbx --db-secret hush-keepass-master-password --group hush --exclude local-only selected-a/);
+  assert.match(commands, /hush:sync keepass --database .*keepass-mirror\.kdbx --db-secret hush-keepass-master-password --group hush --exclude local-only selected-a/);
+  assert.ok(!commands.includes(database));
+  assert.equal(existsSync(database), true);
   assert.match(result.stdout, /sync ok/);
   ok('scheduled run upserts without exposing secret material');
 
@@ -123,6 +130,7 @@ try {
   assert.equal(existsSync(plistPath), false);
   assert.equal(existsSync(configPath), true);
   assert.equal(existsSync(database), true);
+  assert.equal(existsSync(mirror), true);
   ok('remove unloads launchd and retains config plus database');
 
   writeFileSync(log, '');
@@ -132,7 +140,7 @@ try {
   assert.match(commands, /hush:sync keepass .* --dry-run/);
   assert.ok(!commands.includes('hush:set'));
   assert.ok(!commands.includes(' --init'));
-  ok('existing database is validated without recreation or another password prompt');
+  ok('existing mirror is validated without reopening iCloud or prompting again');
 
   process.stdout.write('# KeePass schedule tests done. failures: 0\n');
 } finally {


### PR DESCRIPTION
## what changed

- keep the scheduled KeePassXC working database as an encrypted mode-0600 local mirror
- publish a completed KDBX to the configured iCloud destination after each successful sync
- bound local sync to five minutes and iCloud publishing to thirty seconds
- migrate existing schedules by rerunning `install`

## why

macOS allows an interactive KeePassXC process to open the iCloud KDBX, but the same open from a LaunchAgent blocks in `QFile::open`. Updating the local mirror avoids that headless CloudDocs open while preserving the offline iCloud copy.

## validation

- full macOS suite: 0 failures
- live six-hour LaunchAgent: exit 0 and `sync ok`
- live mirror and iCloud KDBX: 115 entries for 115 eligible Hush names
- temporary launchd cloud-move probe: exit 0, artifacts removed

Closes #16.
