### PR TITLE
ship opt-in encrypted backup scheduling from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,33 @@ on argv, stdout, logs, or a temp plaintext file. The database-password secret is
 Missing entries are created, unique entries are updated, duplicate names fail closed, and multiline
 values are refused rather than truncated.
 
-### schedule it into iCloud (macOS)
+### encrypted snapshots into iCloud (macOS, opt-in)
+
+For whole-store encrypted snapshots instead of a password-manager mirror, npm also ships
+`hush-backup` and `hush-backup-schedule`. Requires GnuPG (`brew install gnupg`).
+
+```sh
+npm install -g @royashbrook/hush
+hush mint hush-backup-key  # only if absent; never overwrite an existing recovery key
+# keep a recovery copy outside this machine's Keychain before proceeding
+hush-backup --dry-run
+hush-backup-schedule install --every 6h --keep 30
+hush-backup-schedule status
+```
+
+Values stream into GPG; only ciphertext snapshots are written. The key is passed on a private
+file descriptor, not in arguments or logs. `run` performs one backup; `remove` stops the schedule
+without removing keys, config, or backups. A loaded job is not proof of backup success: check
+the dated log at `~/Library/Logs/hush-backup.log` and a completed `.gpg` snapshot. iCloud upload
+is handled by macOS, not verified by this tool. Existing manual `com.hush-backup` schedules must
+be retired deliberately before installing the new job.
+
+See [backup options](helpers/README.md#schedule-it-macos) and the packaged
+[recovery runbook](helpers/RESTORE-hush-backup.md). Recovery needs the separately saved key;
+an encrypted backup cannot recover its own key. Scheduling and interactive dialogs are macOS
+only; unattended Bash/GPG backups support an explicit alternate directory on other hosts.
+
+### schedule KeePass into iCloud (macOS)
 
 The npm package includes a Node/launchd helper. A cold setup creates the database if absent, asks for
 its password through hush when needed, performs the first sync, and loads the recurring job:

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ be retired deliberately before installing the new job.
 See [backup options](helpers/README.md#schedule-it-macos) and the packaged
 [recovery runbook](helpers/RESTORE-hush-backup.md). Recovery needs the separately saved key;
 an encrypted backup cannot recover its own key. Scheduling and interactive dialogs are macOS
-only; unattended Bash/GPG backups support an explicit alternate directory on other hosts.
+only. The unattended Bash/GPG path targets POSIX hosts with an explicit alternate directory;
+Windows backup-helper execution is not yet verified.
 
 ### schedule KeePass into iCloud (macOS)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,10 +2,16 @@
 name: hush
 description: "Use whenever an agent needs to STORE, GENERATE, or USE a secret such as an API token, signing key, or password. Hush has one hard rule: the agent never sees plaintext, so it never enters chat, transcripts, stdout, logs, the clipboard, or a temp file. A user-provided value enters once through a hidden prompt; a strong random value can be generated directly into the OS-backed store. Hush later injects it straight into a consumer through an environment variable or stdin, never prints it, and deliberately has no plaintext get command. Trigger on \"store this token\", \"save this key\", \"add it to the keychain\", \"generate an operator/signing key\", \"use the X secret to call Y\", or whenever an agent needs a credential to reach a service. macOS, Linux, and Windows backends are built in; the never-print contract is portable beyond them."
 metadata:
-  version: 1.4.0
+  version: 1.5.0
 ---
 
 # hush
+
+Optional encrypted backup: npm includes `hush-backup` and `hush-backup-schedule`. The scheduler
+uses macOS launchd, defaults to iCloud Drive, and is opt-in. Follow the README's encrypted-backup
+section: first ensure a backup key exists and the human keeps a separate recovery copy. Never
+read the key into agent context. `--dry-run` checks names and prerequisites without reading values.
+Do not replace a legacy schedule silently; remove only the old job after confirming migration.
 
 A secret store for AI agents, with **one hard rule: the agent never sees the plaintext.**
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -106,10 +106,29 @@ hush-backup --help
 Env knobs: `HUSH_BACKUP_DIR` (dest, default iCloud Drive/hush-backups), `HUSH_BACKUP_KEY` (key name,
 default `hush-backup-key`), `HUSH_BACKUP_KEEP` (retention, default 30).
 
-### schedule it (daily, macOS)
+### schedule it (macOS)
 
-See `com.hush-backup.plist`, customize the script path, copy to `~/Library/LaunchAgents/`, and load it
-(instructions in the plist header).
+The npm package includes both commands; no clone or hand-edited plist is needed:
+
+```sh
+hush-backup --dry-run
+hush-backup-schedule install --every 6h --keep 30
+hush-backup-schedule status
+hush-backup-schedule run
+hush-backup-schedule remove
+```
+
+Install validates the existing iCloud Drive directory, absolute executable paths, key name, and
+a value-free dry-run. Use `--directory PATH` for an explicit alternate destination. Scheduled
+runs write dated start/success/failure lines to `~/Library/Logs/hush-backup.log`, never values.
+The first run happens on load; subsequent runs use equal local-time calendar slots. macOS may
+require consent for background access to iCloud Drive. Verify a completed backup in the log;
+`status` proves job registration, not a successful backup or remote iCloud upload.
+
+`remove` keeps the config, keys, and snapshots. Reinstall refreshes the absolute paths after an
+npm/Node relocation. The legacy `com.hush-backup.plist` remains supported for existing users:
+installation refuses to create a duplicate while that plist or job exists. Deliberately unload
+and retire the old job before migrating; do not delete its key or backup directory.
 
 ### restore / disaster recovery
 

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -139,3 +139,11 @@ and no hush. The backup file is plain `gpg --symmetric` AES256, so any gpg on an
 
 macOS (the dialog + Keychain + iCloud path), `gpg` (`brew install gnupg`), and hush on PATH. The
 recovery runbook needs only `gpg` + `base64`, so a backup made here restores anywhere.
+
+### verification scope
+
+The manual CI matrix exercises core storage, sync logic and cold adoption on macOS, Linux and
+Windows. Launchd fixture suites run on macOS/Linux with POSIX fake executables; Windows instead
+verifies each real scheduler refuses installation with its documented macOS-only error. This is
+not Windows scheduling support. `node test/backup-live.mjs` is an opt-in real macOS integration
+check using only a disposable namespace, synthetic values and a uniquely labelled launchd job.

--- a/helpers/hush-backup
+++ b/helpers/hush-backup
@@ -17,14 +17,15 @@
 #
 # NEVER-PRINT CONTRACT HOLDS. Enumerate names with `hush list`; `hush pipe <name> -- base64` streams
 # each value straight into the bundle pipe and on into gpg. Plaintext goes keychain -> gpg -> ciphertext,
-# never to stdout, the transcript, or unencrypted disk. The key (in --auto) flows `hush pipe -> gpg fd`
-# via process substitution, never printed. Interactive passphrase is collected via a hidden macOS dialog.
+# never to stdout, the transcript, or unencrypted disk. The key is captured in a private shell variable
+# then passed on fd 3, never argv. Interactive passphrase uses a hidden macOS dialog.
 #
 # See helpers/RESTORE-hush-backup.md for the full recovery runbook (raw gpg, no hush needed).
 #
 # Usage:
 #   hush-backup                 # interactive backup (hidden passphrase dialog)
 #   hush-backup --auto          # unattended backup keyed from hush (for launchd/cron)
+#   hush-backup --dry-run       # validate prerequisites and names only, read no values
 #   hush-backup --restore <f>   # decrypt <f> and re-set each secret into hush
 #   hush-backup --help
 #
@@ -32,19 +33,30 @@
 #   HUSH_BACKUP_DIR   dest folder (default: iCloud Drive/hush-backups)
 #   HUSH_BACKUP_KEY   hush secret name used as the key in --auto (default: hush-backup-key)
 #   HUSH_BACKUP_KEEP  retention: keep this many newest backups (default: 30)
+#   HUSH_BACKUP_HUSH / HUSH_BACKUP_GPG  absolute executable paths for schedulers
 
+set +x 2>/dev/null || true
+unset BASH_XTRACEFD 2>/dev/null || true
 set -uo pipefail
+umask 077
 
 ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
 DEST_DIR="${HUSH_BACKUP_DIR:-$ICLOUD/hush-backups}"
 KEY_NAME="${HUSH_BACKUP_KEY:-hush-backup-key}"
 KEEP="${HUSH_BACKUP_KEEP:-30}"
+HUSH_BIN="${HUSH_BACKUP_HUSH:-hush}"
+GPG_BIN="${HUSH_BACKUP_GPG:-gpg}"
 
 die() { printf 'hush-backup: %s\n' "$1" >&2; exit 1; }
 log() { printf 'hush-backup: %s\n' "$1"; }
 
-command -v hush >/dev/null 2>&1 || die "hush is not on PATH"
-command -v gpg  >/dev/null 2>&1 || die "gpg is not installed"
+case "${1:-}" in --help|-h) sed -n '2,36p' "$0"; exit 0 ;; esac
+command -v "$HUSH_BIN" >/dev/null 2>&1 || die "hush is not on PATH"
+command -v "$GPG_BIN" >/dev/null 2>&1 || die "gpg is not installed"
+case "$KEEP" in ''|*[!0-9]*) die 'retention must be a positive integer (1-10000)' ;; esac
+[ "${#KEEP}" -le 5 ] && [ "$KEEP" -ge 1 ] && [ "$KEEP" -le 10000 ] || die 'retention must be a positive integer (1-10000)'
+KEEP=$((10#$KEEP))
+case "$DEST_DIR" in *$'\n'*|*$'\r'*) die 'destination must not contain newlines' ;; esac
 
 GPG_ENC=(--batch --yes --pinentry-mode loopback --passphrase-fd 3
          --symmetric --cipher-algo AES256 --s2k-digest-algo SHA512 --s2k-count 65011712)
@@ -60,12 +72,12 @@ ask_pass() { # $1 = prompt
 # Write "name<TAB>base64(value)\n" for every hush secret to stdout. Values transit the pipe only.
 emit_bundle() {
   local names n
-  names="$(hush list 2>/dev/null | sed '/^[[:space:]]*$/d')" || return 1
+  names="$("$HUSH_BIN" list 2>/dev/null | sed '/^[[:space:]]*$/d')" || return 1
   [ -n "$names" ] || return 2
   while IFS= read -r n; do
     [ -n "$n" ] || continue
     printf '%s\t' "$n"
-    hush pipe "$n" -- base64 | tr -d '\n' || return 7   # tr: one line per value (GNU base64 wraps on encode)
+    "$HUSH_BIN" pipe "$n" -- base64 2>/dev/null | tr -d '\n' || return 7   # GNU base64 wraps on encode
     printf '\n'
   done <<EOF
 $names
@@ -74,24 +86,61 @@ EOF
 
 # Retention: keep newest $KEEP backups, delete older.
 prune() {
-  local old
-  old="$(ls -t "$DEST_DIR"/hush-backup-*.gpg 2>/dev/null | tail -n +"$((KEEP + 1))")" || return 0
+  local old f base
+  local files=()
+  for f in "$DEST_DIR"/hush-backup-*.gpg; do
+    [ -f "$f" ] && [ ! -L "$f" ] || continue
+    base="${f##*/}"
+    [[ "$base" =~ ^hush-backup-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}(-[a-zA-Z0-9]+)?\.gpg$ ]] || continue
+    files+=("$f")
+  done
+  [ "${#files[@]}" -gt "$KEEP" ] || return 0
+  # Only our validated ASCII basenames; DEST_DIR rejects newlines. BSD/GNU ls both sort mtime.
+  # shellcheck disable=SC2012
+  old="$(ls -t "${files[@]}" 2>/dev/null | tail -n +"$((KEEP + 1))")" || return 0
   [ -n "$old" ] || return 0
-  printf '%s\n' "$old" | while IFS= read -r f; do [ -n "$f" ] && rm -f "$f"; done
+  printf '%s\n' "$old" | while IFS= read -r f; do
+    case "$f" in "$DEST_DIR"/hush-backup-*.gpg) [ -f "$f" ] && [ ! -L "$f" ] && rm -f "$f" ;; esac
+  done
   log "pruned $(printf '%s\n' "$old" | grep -c .) old backup(s), keeping newest $KEEP"
 }
 
-out_path() { printf '%s/hush-backup-%s.gpg' "$DEST_DIR" "$(date '+%Y-%m-%d-%H%M%S')"; }
+out_path() { printf '%s/hush-backup-%s' "$DEST_DIR" "$(date '+%Y-%m-%d-%H%M%S')"; }
+
+encrypt() {
+  tmp="$(mktemp "$DEST_DIR/.hush-backup-XXXXXX")" || die 'could not stage encrypted backup'
+  out="$(out_path)-${tmp##*-}.gpg"
+  trap 'rm -f "$tmp"' EXIT
+  emit_bundle | "$GPG_BIN" "${GPG_ENC[@]}" -o "$tmp" 3< <(printf '%s\n' "$pass") 2>/dev/null || die 'encryption failed, nothing published'
+  unset pass
+  [ -s "$tmp" ] || die 'empty output, aborted'
+  mv "$tmp" "$out" || die 'could not place backup'
+  trap - EXIT
+  prune
+  log "encrypted backup -> $out"
+}
 
 mode="backup"; infile=""
 case "${1:-}" in
   --auto)    mode="auto" ;;
+  --dry-run) mode="dry-run" ;;
   --restore) mode="restore"; infile="${2:-}" ;;
   --help|-h) sed -n '2,40p' "$0"; exit 0 ;;
   "") ;;
   *) die "unknown arg: $1  (no args = interactive backup; --auto; --restore <file>)" ;;
 esac
 
+if [ "$mode" = dry-run ] || [ "$mode" = auto ]; then
+  names="$("$HUSH_BIN" list 2>/dev/null)" || die 'could not list hush names'
+  grep -qxF -- "$KEY_NAME" <<<"$names" || die "key '$KEY_NAME' not in hush; mint it and keep a separate recovery copy"
+fi
+if [ "$mode" = dry-run ]; then
+  probe="$DEST_DIR"
+  while [ ! -e "$probe" ]; do probe="$(dirname "$probe")"; done
+  [ -d "$probe" ] && [ -w "$probe" ] || die 'destination is not writable'
+  log 'dry-run ok: names and prerequisites only; no values read or files written'
+  exit 0
+fi
 mkdir -p "$DEST_DIR" 2>/dev/null || die "could not create $DEST_DIR"
 
 case "$mode" in
@@ -100,31 +149,16 @@ case "$mode" in
     [ -n "$pass" ] || die "no passphrase entered (cancelled)"
     pass2="$(ask_pass "Re-enter to confirm.")"
     [ "$pass" = "$pass2" ] || die "passphrases did not match, nothing written"
-    out="$(out_path)"; tmp="$(mktemp)" || die "mktemp failed"
-    trap 'rm -f "$tmp"' EXIT
-    emit_bundle | gpg "${GPG_ENC[@]}" -o "$tmp" 3<<<"$pass" || die "encryption failed, nothing written"
-    [ -s "$tmp" ] || die "empty output, aborted"
-    mv "$tmp" "$out" || die "could not place backup"; trap - EXIT
-    prune
-    log "encrypted $(hush list | grep -c .) secret(s) to:"; printf '  %s\n' "$out"
+    unset pass2
+    encrypt
     log "restore: hush-backup --restore \"$out\""
     ;;
 
   auto)
-    # Unattended: the key comes from hush. Verify it exists first, else an empty fd would encrypt
-    # with an empty passphrase.
-    # NB: no `hush list | grep -q` , grep -q exits on match, SIGPIPEs hush list, and `set -o pipefail`
-    # turns that into a false failure once the store is big enough. read into a here-string instead.
-    grep -qxF "$KEY_NAME" <<<"$(hush list 2>/dev/null)" \
-      || die "key '$KEY_NAME' not in hush. mint it once: hush mint $KEY_NAME (then stow a copy)"
-    out="$(out_path)"; tmp="$(mktemp)" || die "mktemp failed"
-    trap 'rm -f "$tmp"' EXIT
-    emit_bundle | gpg "${GPG_ENC[@]}" -o "$tmp" 3< <(hush pipe "$KEY_NAME" -- cat) \
-      || die "encryption failed, nothing written"
-    [ -s "$tmp" ] || die "empty output, aborted"
-    mv "$tmp" "$out" || die "could not place backup"; trap - EXIT
-    prune
-    log "auto backup: $(hush list | grep -c .) secret(s) -> $out"
+    # Check the READ, not just the name. Process substitution hides a failed key read.
+    pass="$("$HUSH_BIN" pipe "$KEY_NAME" -- cat 2>/dev/null)" || die 'could not read backup key; nothing encrypted'
+    [ -n "$pass" ] || die 'backup key is empty; nothing encrypted'
+    encrypt
     ;;
 
   restore)
@@ -132,7 +166,7 @@ case "$mode" in
     [ -f "$infile" ] || die "no such file: $infile"
     pass="$(ask_pass "Passphrase / hush-backup-key to RESTORE from $(basename "$infile").")"
     [ -n "$pass" ] || die "no passphrase entered (cancelled)"
-    bundle="$(gpg "${GPG_DEC[@]}" "$infile" 3<<<"$pass")" \
+    bundle="$("$GPG_BIN" "${GPG_DEC[@]}" "$infile" 3<<<"$pass" 2>/dev/null)" \
       || die "decryption failed (wrong key or corrupt file)"
     count="$(printf '%s\n' "$bundle" | grep -c .)"
     [ "$count" -gt 0 ] || die "decrypted but contained no entries"
@@ -141,7 +175,7 @@ case "$mode" in
     n=0
     while IFS=$'\t' read -r name b64; do
       [ -n "$name" ] || continue
-      printf '%s' "$b64" | base64 -d | hush set "$name" >/dev/null 2>&1 \
+      printf '%s' "$b64" | base64 -d | "$HUSH_BIN" set "$name" >/dev/null 2>&1 \
         || die "failed to restore '$name' (stopped; $n already done)"
       n=$((n + 1))
     done <<<"$bundle"

--- a/helpers/hush-backup
+++ b/helpers/hush-backup
@@ -122,9 +122,9 @@ encrypt() {
 
 mode="backup"; infile=""
 case "${1:-}" in
-  --auto)    mode="auto" ;;
-  --dry-run) mode="dry-run" ;;
-  --restore) mode="restore"; infile="${2:-}" ;;
+  --auto)    [ "$#" -eq 1 ] || die 'usage: hush-backup --auto'; mode="auto" ;;
+  --dry-run) [ "$#" -eq 1 ] || die 'usage: hush-backup --dry-run'; mode="dry-run" ;;
+  --restore) [ "$#" -eq 2 ] || die 'usage: hush-backup --restore <file.gpg>'; mode="restore"; infile="$2" ;;
   --help|-h) sed -n '2,40p' "$0"; exit 0 ;;
   "") ;;
   *) die "unknown arg: $1  (no args = interactive backup; --auto; --restore <file>)" ;;
@@ -164,7 +164,7 @@ case "$mode" in
   restore)
     [ -n "$infile" ] || die "usage: hush-backup --restore <file.gpg>"
     [ -f "$infile" ] || die "no such file: $infile"
-    pass="$(ask_pass "Passphrase / hush-backup-key to RESTORE from $(basename "$infile").")"
+    pass="$(ask_pass "Passphrase / hush-backup-key to RESTORE this backup.")"
     [ -n "$pass" ] || die "no passphrase entered (cancelled)"
     bundle="$("$GPG_BIN" "${GPG_DEC[@]}" "$infile" 3<<<"$pass" 2>/dev/null)" \
       || die "decryption failed (wrong key or corrupt file)"

--- a/helpers/hush-backup-schedule.mjs
+++ b/helpers/hush-backup-schedule.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { launchdCalendarXml } from './launchd-calendar.mjs';
+
+const script = fileURLToPath(import.meta.url);
+const helper = path.join(path.dirname(script), 'hush-backup');
+const home = process.env.HUSH_BACKUP_SCHEDULE_HOME || os.homedir();
+const label = process.env.HUSH_BACKUP_SCHEDULE_LABEL || 'com.royashbrook.hush.backup';
+if (!/^com\.royashbrook\.hush\.backup(?:\.test-[a-zA-Z0-9-]+)?$/.test(label)) throw new Error('invalid job label');
+const configFile = path.join(home, 'Library/Application Support/hush/backup-schedule.json');
+const plistFile = path.join(home, 'Library/LaunchAgents', `${label}.plist`);
+const logFile = path.join(home, 'Library/Logs/hush-backup.log');
+const domain = `gui/${process.getuid?.()}`;
+const target = `${domain}/${label}`;
+const cloud = path.join(home, 'Library/Mobile Documents/com~apple~CloudDocs');
+const xml = (value) => String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&apos;');
+const call = (exe, args, env = process.env) => spawnSync(exe, args, { env, encoding: 'utf8', timeout: 300000, maxBuffer: 1024 * 1024 });
+const fail = (message) => { throw new Error(message); };
+const log = (message) => console.log(`hush-backup-schedule: ${new Date().toISOString()} ${message}`);
+
+function executable(name, override) {
+  const candidates = override ? [override] : (process.env.PATH || '').split(path.delimiter).map((p) => path.resolve(p, name));
+  for (const candidate of candidates) {
+    try { fs.accessSync(candidate, fs.constants.X_OK); if (fs.statSync(candidate).isFile()) return path.resolve(candidate); } catch {}
+  }
+  fail(`${name} executable not found`);
+}
+function launchctl() { return executable('launchctl', process.env.HUSH_BACKUP_SCHEDULE_LAUNCHCTL); }
+function macOnly() {
+  if ((process.env.HUSH_BACKUP_SCHEDULE_PLATFORM || process.platform) !== 'darwin') fail('schedule management currently supports macOS launchd only');
+}
+function write(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.${process.pid}.tmp`;
+  try { fs.writeFileSync(tmp, data, { mode: 0o600, flag: 'wx' }); fs.renameSync(tmp, file); }
+  finally { fs.rmSync(tmp, { force: true }); }
+}
+function environment(config) {
+  return { ...process.env, PATH: config.path, HUSH_NS: config.namespace,
+    HUSH_BACKUP_HUSH: config.hush, HUSH_BACKUP_GPG: config.gpg,
+    HUSH_BACKUP_DIR: config.directory, HUSH_BACKUP_KEY: config.key, HUSH_BACKUP_KEEP: String(config.keep) };
+}
+function read(file) {
+  const config = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (config.version !== 1 || !['hush', 'gpg', 'bash', 'directory', 'key', 'namespace', 'path'].every((key) => typeof config[key] === 'string')
+    || !Number.isInteger(config.keep) || config.keep < 1 || config.keep > 10000) fail('invalid schedule config; reinstall');
+  return config;
+}
+function install(args) {
+  macOnly();
+  const options = { directory: path.join(cloud, 'hush-backups'), key: 'hush-backup-key', keep: '30', every: '6h' };
+  let customDirectory = false;
+  while (args.length) {
+    const key = args.shift();
+    if (!['--directory', '--key-secret', '--keep', '--every'].includes(key) || !args.length) fail('invalid install option; see --help');
+    const name = key === '--key-secret' ? 'key' : key.slice(2);
+    options[name] = args.shift();
+    if (name === 'directory') customDirectory = true;
+  }
+  if (!customDirectory && (!fs.existsSync(cloud) || !fs.statSync(cloud).isDirectory())) fail('iCloud Drive is unavailable; enable it or provide --directory');
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(options.key)) fail('invalid backup key name');
+  if (!/^\d+$/.test(options.keep) || Number(options.keep) < 1 || Number(options.keep) > 10000) fail('--keep must be 1-10000');
+  const interval = /^(\d+)(m|h)$/.exec(options.every);
+  const seconds = interval && Number(interval[1]) * (interval[2] === 'm' ? 60 : 3600);
+  if (!seconds || seconds < 300 || 86400 % seconds !== 0) fail('--every must divide one day into equal slots, minimum 5m (for example 30m, 6h, 24h)');
+  const config = { version: 1, directory: path.resolve(options.directory), key: options.key, keep: Number(options.keep), every: options.every, seconds,
+    hush: executable('hush', process.env.HUSH_BACKUP_HUSH || path.join(path.dirname(script), '../hush')),
+    gpg: executable('gpg', process.env.HUSH_BACKUP_GPG), bash: executable('bash', process.env.HUSH_BACKUP_BASH),
+    namespace: process.env.HUSH_NS || 'hush', path: process.env.PATH || '/usr/bin:/bin' };
+  const ctl = launchctl();
+  const legacyFile = path.join(home, 'Library/LaunchAgents/com.hush-backup.plist');
+  if (fs.existsSync(legacyFile) || call(ctl, ['print', `${domain}/com.hush-backup`]).status === 0) {
+    fail('legacy com.hush-backup schedule exists; remove that schedule deliberately before installing this one (keep its key and backups)');
+  }
+  const checked = call(config.bash, [helper, '--dry-run'], environment(config));
+  if (checked.status !== 0) fail('backup dry-run failed; check destination, gpg, and the hush key (mint it once and keep a separate recovery copy)');
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>${xml(label)}</string>
+<key>ProgramArguments</key><array>${[process.execPath, script, 'run', '--config', configFile].map((arg) => `<string>${xml(arg)}</string>`).join('')}</array>
+<key>StartCalendarInterval</key>${launchdCalendarXml(seconds)}
+<key>RunAtLoad</key><true/>
+<key>StandardOutPath</key><string>${xml(logFile)}</string>
+<key>StandardErrorPath</key><string>${xml(logFile)}</string>
+</dict></plist>\n`;
+  // Preserve the previous working schedule if reinstallation cannot load the replacement.
+  const oldConfig = fs.existsSync(configFile) ? fs.readFileSync(configFile) : null;
+  const oldPlist = fs.existsSync(plistFile) ? fs.readFileSync(plistFile) : null;
+  const wasLoaded = call(ctl, ['print', target]).status === 0;
+  if (wasLoaded && !oldPlist) fail('loaded job has no owned plist; inspect it before reinstalling');
+  fs.mkdirSync(path.dirname(logFile), { recursive: true });
+  if (wasLoaded && call(ctl, ['bootout', target]).status !== 0) fail('could not unload current schedule; nothing replaced');
+  try {
+    write(configFile, `${JSON.stringify(config, null, 2)}\n`);
+    write(plistFile, plist);
+    if (call(ctl, ['bootstrap', domain, plistFile]).status !== 0) fail('launchctl bootstrap failed');
+  } catch (error) {
+    if (oldConfig) write(configFile, oldConfig); else fs.rmSync(configFile, { force: true });
+    if (oldPlist) write(plistFile, oldPlist); else fs.rmSync(plistFile, { force: true });
+    if (wasLoaded && call(ctl, ['bootstrap', domain, plistFile]).status !== 0) fail('install failed; old files restored but old job could not reload');
+    throw error;
+  }
+  log(`installed ${options.every}; keep a recovery copy of the backup key outside this Keychain. log: ${logFile}`);
+}
+function run(file) {
+  const config = read(file);
+  log('backup starting');
+  const result = call(config.bash, [helper, '--auto'], environment(config));
+  if (result.status !== 0) fail(`backup failed (${result.error?.code || result.status}); no child output logged`);
+  log('backup ok');
+}
+function status() {
+  macOnly();
+  const loaded = call(launchctl(), ['print', target]).status === 0;
+  log(`${loaded ? 'loaded' : 'not loaded'}; config: ${configFile}; log: ${logFile}`);
+  process.exitCode = loaded ? 0 : 1;
+}
+function remove() {
+  macOnly();
+  const ctl = launchctl();
+  if (call(ctl, ['print', target]).status === 0 && call(ctl, ['bootout', target]).status !== 0) fail('could not unload schedule; plist preserved');
+  fs.rmSync(plistFile, { force: true });
+  log('schedule removed; config, encrypted backups and Keychain entries retained');
+}
+const [command = 'help', ...args] = process.argv.slice(2);
+try {
+  if (command === 'install') install(args);
+  else if (command === 'run' && (!args.length || (args.length === 2 && args[0] === '--config'))) run(args[1] || configFile);
+  else if (command === 'status' && !args.length) status();
+  else if (command === 'remove' && !args.length) remove();
+  else if (['help', '--help', '-h'].includes(command)) console.log(`hush-backup-schedule: opt-in encrypted backups (macOS launchd)
+  install [--directory PATH] [--key-secret NAME] [--keep 30] [--every 6h]
+  run | status | remove
+Default destination: iCloud Drive/hush-backups. Requires GnuPG and an existing Hush backup key.
+First: hush mint hush-backup-key, then keep a recovery copy outside this Keychain.
+Install checks names/prerequisites without reading values; launchd runs the first backup on load.
+Only ciphertext is written. Remove preserves backups, config, and secrets. Schedule slots use local time.`);
+  else fail('invalid command or arguments; see --help');
+} catch (error) { console.error(`hush-backup-schedule: ${error.message}`); process.exitCode = 1; }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,21 @@
 {
   "name": "@royashbrook/hush",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "a secret store for AI agents with one rule: the agent never sees the plaintext. get a secret once into the OS keychain, then inject it into commands forever. no get, cross-platform, MIT.",
   "bin": {
     "hush": "hush",
+    "hush-backup": "helpers/hush-backup",
+    "hush-backup-schedule": "helpers/hush-backup-schedule.mjs",
     "hush-bitwarden-schedule": "helpers/hush-bitwarden-schedule.mjs",
     "hush-lastpass-schedule": "helpers/hush-lastpass-schedule.mjs",
     "hush-keepass-schedule": "helpers/hush-keepass-schedule.mjs"
   },
   "files": [
     "hush",
+    "helpers/hush-backup",
+    "helpers/hush-backup-schedule.mjs",
+    "helpers/RESTORE-hush-backup.md",
+    "helpers/README.md",
     "helpers/hush-bitwarden-json.mjs",
     "helpers/hush-bitwarden-schedule.mjs",
     "helpers/hush-lastpass-schedule.mjs",

--- a/test/backup-live.mjs
+++ b/test/backup-live.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Opt-in macOS integration test: real Keychain, GPG, and a uniquely labelled launchd job.
+// Uses synthetic data, a disposable namespace/directory, and removes the job and entries afterward.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = process.env.HUSH_BACKUP_TEST_PACKAGE || path.resolve(here, '..');
+const hush = path.join(repo, 'hush');
+const runner = path.join(repo, 'helpers/hush-backup-schedule.mjs');
+if (process.argv[2] === '--verify') {
+  const gpg = spawn('gpg', ['--batch', '--pinentry-mode', 'loopback', '--passphrase-fd', '3', '--quiet', '-d', process.argv[3]], { stdio: ['ignore', 'pipe', 'pipe', 'pipe'] });
+  gpg.stdio[3].end(`${process.env.TEST_KEY}\n`);
+  let bundle = '';
+  gpg.stdout.on('data', (data) => { bundle += data; });
+  gpg.stderr.resume();
+  gpg.on('close', (code) => {
+    const rows = new Map(bundle.trim().split('\n').map((line) => line.split('\t')));
+    if (code !== 0 || rows.size !== 2 || Buffer.from(rows.get('sample') || '', 'base64').toString() !== 'synthetic-backup-live'
+      || Buffer.from(rows.get('backup-key') || '', 'base64').toString() !== process.env.TEST_KEY) process.exitCode = 1;
+    else console.log('ok: raw GPG roundtrip, exact two-entry bundle');
+  });
+} else {
+  assert.equal(process.platform, 'darwin', 'live test requires macOS');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hush-backup-live-'));
+  const label = `com.royashbrook.hush.backup.test-${process.pid}`;
+  const env = { ...process.env, HUSH_NS: `hush-backup-live-${process.pid}`, HUSH_PROMPT: 'pipe',
+    HUSH_BACKUP_SCHEDULE_HOME: root, HUSH_BACKUP_SCHEDULE_LABEL: label };
+  const dest = path.join(root, 'ciphertext');
+  const run = (exe, args, input) => {
+    const result = spawnSync(exe, args, { env, input, encoding: 'utf8', timeout: 30000 });
+    assert.ok(!`${result.stdout}${result.stderr}`.includes('synthetic-backup-live'), 'value leaked');
+    return result;
+  };
+  try {
+    assert.equal(run(hush, ['set', 'sample'], 'synthetic-backup-live').status, 0, 'store synthetic sample');
+    assert.equal(run(hush, ['mint', 'backup-key']).status, 0, 'mint isolated key');
+    assert.equal(run(process.execPath, [runner, 'install', '--directory', dest, '--key-secret', 'backup-key', '--keep', '2']).status, 0, 'load disposable job');
+    const logfile = path.join(root, 'Library/Logs/hush-backup.log');
+    const deadline = Date.now() + 25000;
+    while (Date.now() < deadline && !(fs.existsSync(logfile) && fs.readFileSync(logfile, 'utf8').includes('backup ok'))) {
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    assert.ok(fs.existsSync(logfile) && fs.readFileSync(logfile, 'utf8').includes('backup ok'), 'launchd RunAtLoad must complete a backup');
+    assert.equal(run(process.execPath, [runner, 'status']).status, 0);
+    const files = fs.readdirSync(dest).filter((name) => name.endsWith('.gpg'));
+    assert.equal(files.length, 1);
+    const checked = run(hush, ['run', 'TEST_KEY=backup-key', '--', process.execPath, fileURLToPath(import.meta.url), '--verify', path.join(dest, files[0])]);
+    assert.equal(checked.status, 0, 'raw GPG must verify the exact original values without printing them');
+    assert.ok(!fs.readFileSync(logfile, 'utf8').includes('synthetic-backup-live'));
+    assert.equal(run(process.execPath, [runner, 'remove']).status, 0);
+    assert.notEqual(run(process.execPath, [runner, 'status']).status, 0);
+    assert.ok(fs.existsSync(path.join(dest, files[0])), 'removal must preserve ciphertext');
+    console.log('ok: real launchd RunAtLoad + Keychain + GPG roundtrip + retained ciphertext on remove');
+  } finally {
+    run('/bin/launchctl', ['bootout', `gui/${process.getuid()}/${label}`]);
+    run(hush, ['rm', 'sample']);
+    run(hush, ['rm', 'backup-key']);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/test/backup-schedule.mjs
+++ b/test/backup-schedule.mjs
@@ -67,6 +67,9 @@ const files = () => fs.existsSync(dest) ? fs.readdirSync(dest).filter((name) => 
 try {
   schedule(['--help']);
   backup(['--help']);
+  backup(['--auto', 'unexpected'], 1);
+  backup(['--dry-run', 'unexpected'], 1);
+  backup(['--restore'], 1);
   schedule(['install'], 1); // Missing iCloud must not be invented by mkdir.
   assert.ok(!fs.existsSync(config));
   backup(['--dry-run']);

--- a/test/backup-schedule.mjs
+++ b/test/backup-schedule.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hush-backup-test-'));
+const home = path.join(root, 'home');
+const bin = path.join(root, 'bin');
+const dest = path.join(root, 'encrypted');
+const cloud = path.join(home, 'Library/Mobile Documents/com~apple~CloudDocs');
+const config = path.join(home, 'Library/Application Support/hush/backup-schedule.json');
+const plist = path.join(home, 'Library/LaunchAgents/com.royashbrook.hush.backup.plist');
+fs.mkdirSync(bin, { recursive: true });
+function fake(name, source) {
+  const file = path.join(bin, name);
+  fs.writeFileSync(file, `#!${process.execPath}\n${source}`, { mode: 0o755 });
+  return file;
+}
+const hush = fake('hush', `
+const a = process.argv.slice(2);
+if (a[0] === 'list') { if (process.env.FAIL_LIST) process.exit(1); console.log('hush-backup-key\\nalpha'); }
+else if (a[0] === 'pipe') {
+  if (a[1] === 'hush-backup-key' && process.env.FAIL_KEY) process.exit(1);
+  const value = a[1] === 'hush-backup-key' ? (process.env.EMPTY_KEY ? '' : 'fixture-backup-key') : 'fixture-backup-value';
+  process.stdout.write(a[3] === 'base64' ? Buffer.from(value).toString('base64') : value);
+} else process.exit(1);
+`);
+const gpg = fake('gpg', `
+const fs = require('node:fs');
+const a = process.argv.slice(2);
+const pass = fs.readFileSync(3, 'utf8').trim();
+const bundle = fs.readFileSync(0, 'utf8');
+if (pass !== 'fixture-backup-key' || !bundle.includes('alpha\\t' + Buffer.from('fixture-backup-value').toString('base64'))) process.exit(2);
+fs.writeFileSync(a[a.indexOf('-o') + 1], 'FAKE-CIPHERTEXT');
+if (process.env.FAIL_GPG) { console.error('fixture-backup-value'); process.exit(1); }
+`);
+const ctl = fake('launchctl', `
+const fs = require('node:fs');
+const a = process.argv.slice(2), state = process.env.TEST_STATE, once = process.env.TEST_FAIL_ONCE;
+if (a[0] === 'print') process.exit(a[1].endsWith('/com.hush-backup') ? 1 : fs.existsSync(state) ? 0 : 1);
+if (a[0] === 'bootout') { fs.rmSync(state, {force:true}); process.exit(0); }
+if (a[0] === 'bootstrap') {
+  if (once && fs.existsSync(once)) { fs.rmSync(once); process.exit(1); }
+  if (!fs.existsSync(a[2])) process.exit(1);
+  fs.writeFileSync(state, 'loaded'); process.exit(0);
+}
+process.exit(1);
+`);
+const env = { ...process.env, HUSH_NS: 'synthetic-backup-test', HUSH_BACKUP_SCHEDULE_HOME: home,
+  HUSH_BACKUP_SCHEDULE_PLATFORM: 'darwin', HUSH_BACKUP_HUSH: hush, HUSH_BACKUP_GPG: gpg,
+  HUSH_BACKUP_SCHEDULE_LAUNCHCTL: ctl, TEST_STATE: path.join(root, 'loaded'),
+  TEST_FAIL_ONCE: path.join(root, 'fail-once'), HUSH_BACKUP_DIR: dest,
+  PATH: `${bin}${path.delimiter}${process.env.PATH}` };
+const secrets = ['fixture-backup-key', 'fixture-backup-value'];
+function check(result, status = 0) {
+  for (const value of secrets) assert.ok(!`${result.stdout}${result.stderr}`.includes(value), 'value leaked to output');
+  assert.equal(result.status, status, result.stderr);
+  return result;
+}
+const schedule = (args, status = 0, extra = {}) => check(spawnSync(process.execPath, [path.join(repo, 'helpers/hush-backup-schedule.mjs'), ...args], { env: { ...env, ...extra }, encoding: 'utf8' }), status);
+const backup = (args, status = 0, extra = {}) => check(spawnSync('bash', [path.join(repo, 'helpers/hush-backup'), ...args], { env: { ...env, ...extra }, encoding: 'utf8' }), status);
+const files = () => fs.existsSync(dest) ? fs.readdirSync(dest).filter((name) => name.endsWith('.gpg')) : [];
+try {
+  schedule(['--help']);
+  backup(['--help']);
+  schedule(['install'], 1); // Missing iCloud must not be invented by mkdir.
+  assert.ok(!fs.existsSync(config));
+  backup(['--dry-run']);
+  assert.ok(!fs.existsSync(dest), 'dry-run must not create destination');
+  backup(['--auto'], 1, { FAIL_KEY: '1' });
+  backup(['--auto'], 1, { EMPTY_KEY: '1' });
+  backup(['--auto'], 1, { FAIL_LIST: '1' });
+  backup(['--auto'], 1, { FAIL_GPG: '1' });
+  assert.deepEqual(files(), [], 'failed encryption must not publish');
+  assert.deepEqual(fs.readdirSync(dest), [], 'failed encryption cleans staging ciphertext');
+  for (const keep of ['0', '-1', 'wat', '10001']) backup(['--auto'], 1, { HUSH_BACKUP_KEEP: keep });
+  backup(['--auto'], 0, { SHELLOPTS: 'xtrace', HUSH_BACKUP_KEEP: '02' });
+  backup(['--auto'], 0, { HUSH_BACKUP_KEEP: '2' });
+  assert.equal(files().length, 2, 'same-second backups do not overwrite');
+  backup(['--auto'], 0, { HUSH_BACKUP_KEEP: '2' });
+  assert.equal(files().length, 2, 'retention bounded');
+  fs.writeFileSync(path.join(dest, 'unrelated.gpg'), 'keep');
+  backup(['--auto'], 0, { HUSH_BACKUP_KEEP: '1' });
+  assert.ok(fs.existsSync(path.join(dest, 'unrelated.gpg')), 'retention preserves unrelated files');
+  schedule(['install', '--directory', dest], 1, { FAIL_LIST: '1' });
+  assert.ok(!fs.existsSync(config), 'failed dry-run cannot install');
+  schedule(['install', '--directory', dest, '--every', '7h'], 1);
+  schedule(['install', '--directory', dest, '--keep', '0'], 1);
+  fs.mkdirSync(cloud, { recursive: true });
+  schedule(['install', '--directory', dest, '--keep', '2']);
+  const original = fs.readFileSync(config, 'utf8');
+  assert.equal(JSON.parse(original).namespace, env.HUSH_NS);
+  assert.ok(fs.readFileSync(plist, 'utf8').includes('StartCalendarInterval'));
+  assert.ok(!fs.readFileSync(plist, 'utf8').includes('StartInterval'));
+  if (process.platform !== 'win32') assert.equal(fs.statSync(config).mode & 0o777, 0o600);
+  for (const value of secrets) assert.ok(!original.includes(value), 'config contains secret');
+  schedule(['status']);
+  schedule(['run']);
+  schedule(['run'], 1, { FAIL_GPG: '1' });
+  fs.writeFileSync(env.TEST_FAIL_ONCE, 'fail next bootstrap');
+  schedule(['install', '--directory', dest, '--every', '12h'], 1);
+  assert.equal(fs.readFileSync(config, 'utf8'), original, 'failed reinstall restores previous config');
+  schedule(['status']);
+  const legacy = path.join(home, 'Library/LaunchAgents/com.hush-backup.plist');
+  fs.writeFileSync(legacy, 'legacy');
+  schedule(['install', '--directory', dest], 1);
+  assert.equal(fs.readFileSync(legacy, 'utf8'), 'legacy', 'legacy schedule unchanged');
+  schedule(['remove']);
+  schedule(['remove']);
+  schedule(['status'], 1);
+  assert.ok(fs.existsSync(config) && fs.existsSync(dest) && fs.existsSync(legacy), 'remove preserves data and legacy schedule');
+  assert.ok(!fs.existsSync(plist));
+  console.log('ok   - backup helper and scheduler: dry-run, no leaks, failures, retention, rollback, removal');
+} finally { fs.rmSync(root, { recursive: true, force: true }); }

--- a/test/schedule-platform.mjs
+++ b/test/schedule-platform.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// launchd is macOS-only. POSIX fake executables exercise it on macOS/Linux; Windows checks
+// the real install refusal, not a fake Darwin override that cannot execute Unix shebangs.
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+const name = process.argv[2];
+assert.ok(['lastpass', 'keepass', 'bitwarden', 'backup'].includes(name));
+const here = path.dirname(fileURLToPath(import.meta.url));
+if (process.platform === 'win32') {
+  const env = { ...process.env };
+  delete env[`HUSH_${name.toUpperCase()}_SCHEDULE_PLATFORM`];
+  const result = spawnSync(process.execPath, [path.join(here, `../helpers/hush-${name}-schedule.mjs`), 'install'], { env, encoding: 'utf8' });
+  assert.equal(result.status, 1, 'unsupported host must refuse install');
+  assert.match(result.stderr, /macOS launchd only/);
+  console.log(`ok   - ${name} scheduler refuses Windows; POSIX launchd fixture intentionally not run`);
+} else {
+  const result = spawnSync(process.execPath, [path.join(here, `${name}-schedule.mjs`)], { stdio: 'inherit' });
+  process.exit(result.status ?? 1);
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -91,14 +91,28 @@ env HUSH_PROMPT=bogus "$HUSH" set t-x >/dev/null 2>&1 && bad "bad HUSH_PROMPT ac
 
 # On mac the GUI branch is always reachable (osascript exists), so a bare fall-through would hit the
 # REAL dialog and block/vary by session. Stub osascript on PATH to simulate a no-GUI session (the
-# reported XPC failure) so the fall-through + honest-error paths are deterministic. Non-mac CI has no
-# GUI dialog backend, so the fall-through naturally lands on the final die.
+# reported XPC failure) so the fall-through + honest-error paths are deterministic. Windows has a
+# real WPF dialog too: intercept only its prompt verb, retaining real DPAPI for every other call.
 STUB=""
 if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
   STUB="$(mktemp -d 2>/dev/null || echo "${TMPDIR:-/tmp}/hush-stub-$$")"; mkdir -p "$STUB"
   printf '#!/bin/sh\necho "execution error: Connection Invalid error for service com.apple.hiservices-xpcservice. (-1)" >&2\nexit 1\n' > "$STUB/osascript"
   chmod +x "$STUB/osascript"
 fi
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    STUB="$(mktemp -d)"
+    export HUSH_TEST_REAL_POWERSHELL="$(command -v powershell.exe)"
+    cat > "$STUB/powershell.exe" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  [ "$arg" = prompt ] && { echo 'synthetic GUI unavailable' >&2; exit 1; }
+done
+exec "$HUSH_TEST_REAL_POWERSHELL" "$@"
+EOF
+    chmod +x "$STUB/powershell.exe"
+    ;;
+esac
 run_prompt() { # run hush set with the stub PATH (mac) or bare (else), HUSH_PROMPT cleared
   if [ -n "$STUB" ]; then env -u HUSH_PROMPT PATH="$STUB:$PATH" "$HUSH" "$@"; else env -u HUSH_PROMPT "$HUSH" "$@"; fi
 }
@@ -115,10 +129,10 @@ if [ "$(uname -s 2>/dev/null)" = Darwin ]; then
   out2="$(run_prompt set t-x --gui < /dev/null 2>&1)"
   printf '%s' "$out2" | grep -qi "could not open" && ok "--gui failure honest" || bad "--gui failure not surfaced (got: $out2)"
   "$HUSH" list 2>&1 | grep -qx "t-x" && bad "stored despite dialog failure" || ok "nothing stored on dialog failure"
-  rm -rf "$STUB" 2>/dev/null
 else
   ok "osascript-failure checks (mac-only, skipped on $(uname -s 2>/dev/null))"
 fi
+[ -z "$STUB" ] || rm -rf "$STUB" 2>/dev/null
 "$HUSH" rm t-empty >/dev/null 2>&1; "$HUSH" rm t-x >/dev/null 2>&1
 
 if bash "$(dirname "${BASH_SOURCE[0]:-$0}")/lastpass-sync.sh"; then

--- a/test/test.sh
+++ b/test/test.sh
@@ -141,7 +141,7 @@ else
   bad "isolated LastPass sync suite"
 fi
 
-if node "$(dirname "${BASH_SOURCE[0]:-$0}")/lastpass-schedule.mjs"; then
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/schedule-platform.mjs" lastpass; then
   ok "isolated LastPass schedule suite"
 else
   bad "isolated LastPass schedule suite"
@@ -159,7 +159,7 @@ else
   bad "isolated KeePass sync suite"
 fi
 
-if node "$(dirname "${BASH_SOURCE[0]:-$0}")/keepass-schedule.mjs"; then
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/schedule-platform.mjs" keepass; then
   ok "isolated KeePass schedule suite"
 else
   bad "isolated KeePass schedule suite"
@@ -171,13 +171,13 @@ else
   bad "isolated Bitwarden sync suite"
 fi
 
-if node "$(dirname "${BASH_SOURCE[0]:-$0}")/bitwarden-schedule.mjs"; then
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/schedule-platform.mjs" bitwarden; then
   ok "isolated Bitwarden schedule suite"
 else
   bad "isolated Bitwarden schedule suite"
 fi
 
-if node "$(dirname "${BASH_SOURCE[0]:-$0}")/backup-schedule.mjs"; then
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/schedule-platform.mjs" backup; then
   ok "encrypted backup schedule suite"
 else
   bad "encrypted backup schedule suite"

--- a/test/test.sh
+++ b/test/test.sh
@@ -163,6 +163,12 @@ else
   bad "isolated Bitwarden schedule suite"
 fi
 
+if node "$(dirname "${BASH_SOURCE[0]:-$0}")/backup-schedule.mjs"; then
+  ok "encrypted backup schedule suite"
+else
+  bad "encrypted backup schedule suite"
+fi
+
 if node "$(dirname "${BASH_SOURCE[0]:-$0}")/adoption.mjs"; then
   ok "cold adoption suite"
 else


### PR DESCRIPTION
## changes

Ships hush-backup and a Node-stdlib launchd installer in npm 1.5.0, including the recovery runbook.

- install/run/status/remove, absolute tool paths, value-free dry-run, local calendar slots
- optional iCloud destination by default; explicit alternate directory for other setups
- refuse duplicate legacy jobs, restore previous config on failed reinstall, preserve backups and keys on removal
- fail closed on empty/failed key reads; disable inherited tracing; unique ciphertext staging and bounded retention
- no secret values in config, arguments, or logs; unchanged name/tab/base64 GPG bundle format

## verification

- full existing regression suite plus new adoption/backup suites: zero failures on macOS
- deterministic fake GPG/launchctl coverage: missing dependencies/key, failed read/encryption, dry-run, same-second snapshots, retention, rollback, removal
- ShellCheck, Bash/Node syntax, frontmatter validator and diff checks pass
- real disposable macOS launchd RunAtLoad + Keychain + GPG roundtrip passes, including from a cold-installed npm archive
- real validation uses synthetic data and a unique test namespace/job; existing production backup jobs remain unchanged

Scheduling and interactive dialogs remain macOS-only. A registered job is not proof of successful backup or completed iCloud upload. Keep a separate recovery copy of the key. The new public-content leak scan passes; the whole pre-existing README has a generic host skill-install-path false positive.

fixes #10
